### PR TITLE
Enrollment: add user_id property

### DIFF
--- a/Guardian/EnrollRequest.swift
+++ b/Guardian/EnrollRequest.swift
@@ -72,8 +72,8 @@ public struct EnrollRequest: Requestable {
                         let payload = payload,
                         let id = payload["id"] as? String,
                         let token = payload["token"] as? String,
+                        let userId = payload["user_id"] as? String,
                         let _ = payload["issuer"] as? String,
-                        let _ = payload["user_id"] as? String,
                         let _ = payload["url"] as? String else {
                             return callback(.failure(cause: GuardianError.invalidResponse))
                     }
@@ -84,7 +84,7 @@ public struct EnrollRequest: Requestable {
                     let totpPeriod = totpData?["period"] as? Int
                     let totpDigits = totpData?["digits"] as? Int
 
-                    let enrollment = Enrollment(id: id, deviceToken: token, notificationToken: self.notificationToken, signingKey: self.keyPair.privateKey, base32Secret: totpSecret, algorithm: totpAlgorithm, digits: totpDigits, period: totpPeriod)
+                    let enrollment = Enrollment(id: id, userId: userId, deviceToken: token, notificationToken: self.notificationToken, signingKey: self.keyPair.privateKey, base32Secret: totpSecret, algorithm: totpAlgorithm, digits: totpDigits, period: totpPeriod)
                     callback(.success(payload: enrollment))
                 }
         }

--- a/Guardian/Enrollment.swift
+++ b/Guardian/Enrollment.swift
@@ -36,6 +36,11 @@ public class Enrollment: NSObject {
     public let id: String
 
     /**
+     The id of this enrollment's user
+     */
+    public let userId: String
+
+    /**
      The token used to authenticate when updating the device data or deleting 
      the enrollment
      */
@@ -112,6 +117,7 @@ public class Enrollment: NSObject {
      */
     public init(
          id: String,
+         userId: String,
          deviceToken: String,
          notificationToken: String,
          signingKey: RSAPrivateKey,
@@ -121,6 +127,7 @@ public class Enrollment: NSObject {
          period: Int? = nil
         ) {
         self.id = id
+        self.userId = userId
         self.deviceToken = deviceToken
         self.notificationToken = notificationToken
         self.signingKey = signingKey

--- a/GuardianTests/AuthenticationSpec.swift
+++ b/GuardianTests/AuthenticationSpec.swift
@@ -58,7 +58,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should succeed when notification and enrollment is valid") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -71,7 +71,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when transaction token is not valid") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: "someInvalidTransactionToken", challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -84,7 +84,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when challenge is invalid") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: "anInvalidNotificationChallenge", startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -97,7 +97,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when enrollment signing key is not correct") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: privateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: privateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -134,7 +134,7 @@ class AuthenticationSpec: QuickSpec {
                         return errorResponse(statusCode: 401, errorCode: "invalid_token", message: "Invalid challenge_response")
                     }.name = "Checking challenge_response"
 
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -147,7 +147,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("with reason should succeed when notification and enrollment is valid") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -160,7 +160,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when transaction token is not valid") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: "someInvalidTransactionToken", challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -173,7 +173,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when challenge is invalid") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: "anInvalidNotificationChallenge", startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
@@ -186,7 +186,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when enrollment signing key is not correct") {
-                let enrollment = Enrollment(id: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: privateKey, base32Secret: ValidBase32Secret)
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: privateKey, base32Secret: ValidBase32Secret)
                 let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -59,7 +59,7 @@ class GuardianSpec: QuickSpec {
 
         describe("authentication(forDomain:, session:)") {
 
-            let enrollment = Enrollment(id: "ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: ValidRSAPrivateKey, base32Secret: "SECRET")
+            let enrollment = Enrollment(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: ValidRSAPrivateKey, base32Secret: "SECRET")
 
             it("should return authentication with domain only") {
                 expect(Guardian.authentication(forDomain: "samples.guardian.auth0.com", andEnrollment: enrollment)).toNot(beNil())

--- a/GuardianTests/Matchers.swift
+++ b/GuardianTests/Matchers.swift
@@ -200,6 +200,7 @@ func haveEnrollment(withBaseUrl baseURL: URL, enrollmentId: String, deviceToken:
         if let actual = try expression.evaluate(), case .success(let result) = actual {
             if let result = result {
                 return result.id == enrollmentId
+                    && result.userId == userId
                     && result.deviceToken == deviceToken
                     && result.notificationToken == notificationToken
                     && result.signingKey.tag == signingKey.tag


### PR DESCRIPTION
This property allows to check which auth0 user this enrollment corresponds to.

Assuming the SDK is just used to add an extra feature to an app that has some functionality of its own (that is probably already using lock -or similar-), this allows to check that the 2nd factor matches the logged in user (the app should probably keep the user logged in with a refresh token).

Or also in case the app allows multiple logged in users, this lets you know when to show a "add/delete 2nd factor" on each user's "profile view", or know which enrollment to use to get a OTP code for an specific user.