### PR TITLE
Add methods to register and handle remote notifications

### DIFF
--- a/Guardian/Authentication.swift
+++ b/Guardian/Authentication.swift
@@ -101,7 +101,7 @@ public protocol Authentication {
             let enrollment: Enrollment = ...
             Guardian
                 .authentication(forDomain: "tenant.guardian.auth0.com", andEnrollment: enrollment)
-                .handleAction(withIdentifier: identifier, andNotification: notification)
+                .handleAction(withIdentifier: identifier, notification: notification)
                 .start { result in
                     completionHandler()
             }
@@ -109,7 +109,7 @@ public protocol Authentication {
      }
      ```
      */
-    func handleAction(withIdentifier identifier: String, andNotification notification: Notification) -> Request<Void>
+    func handleAction(withIdentifier identifier: String, notification: Notification) -> Request<Void>
 }
 
 public extension Authentication {
@@ -163,12 +163,14 @@ struct RSAAuthentication: Authentication {
         }
     }
 
-    func handleAction(withIdentifier identifier: String, andNotification notification: Notification) -> Request<Void> {
+    func handleAction(withIdentifier identifier: String, notification: Notification) -> Request<Void> {
         switch identifier {
         case acceptActionIdentifier:
             return allow(notification: notification)
-        default:
+        case rejectActionIdentifier:
             return reject(notification: notification)
+        default:
+            return FailedRequest(error: GuardianError.invalidNotificationActionIdentifier)
         }
     }
 }

--- a/Guardian/Authentication.swift
+++ b/Guardian/Authentication.swift
@@ -86,6 +86,30 @@ public protocol Authentication {
      - returns: a request to execute
      */
     func reject(notification: Notification, withReason reason: String?) -> Request<Void>
+
+    /**
+     Handles the Guardian remote notification action matching the supplied 
+     identifier.
+
+     You could use this method in your AppDelegate's `application(:handleActionWithIdentifier:forRemoteNotification:withResponseInfo:completionHandler)`
+     method to automatically handle the notification actions:
+
+     ```
+     func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], withResponseInfo responseInfo: [AnyHashable : Any], completionHandler: @escaping () -> Void) {
+        if let notification = Guardian.notification(from: userInfo) {
+            /* Get the enrollment that matches the notification ... */
+            let enrollment: Enrollment = ...
+            Guardian
+                .authentication(forDomain: "tenant.guardian.auth0.com", andEnrollment: enrollment)
+                .handleAction(withIdentifier: identifier, andNotification: notification)
+                .start { result in
+                    completionHandler()
+            }
+        }
+     }
+     ```
+     */
+    func handleAction(withIdentifier identifier: String, andNotification notification: Notification) -> Request<Void>
 }
 
 public extension Authentication {
@@ -136,6 +160,15 @@ struct RSAAuthentication: Authentication {
             return self.api.resolve(transaction: transactionToken, withChallengeResponse: jwt)
         } catch(let error) {
             return FailedRequest(error: error)
+        }
+    }
+
+    func handleAction(withIdentifier identifier: String, andNotification notification: Notification) -> Request<Void> {
+        switch identifier {
+        case acceptActionIdentifier:
+            return allow(notification: notification)
+        default:
+            return reject(notification: notification)
         }
     }
 }

--- a/Guardian/GuardianError.swift
+++ b/Guardian/GuardianError.swift
@@ -31,6 +31,7 @@ private let invalidBase32SecretMessage = "a0.guardian.internal.invalid_base32_se
 private let invalidPublicKeyMessage = "a0.guardian.internal.invalid_public_key"
 private let invalidPrivateKeyMessage = "a0.guardian.internal.invalid_private_key"
 private let invalidOTPAlgorithmMessage = "a0.guardian.internal.invalid_otp_algorithm"
+private let invalidNotificationActionIdentifierMessage = "a0.guardian.internal.invalid_notification_action_identifier"
 
 /**
  An `Error` that encapsulates server and other possible internal errors
@@ -113,5 +114,9 @@ internal extension GuardianError {
 
     static var invalidEnrollmentUri: GuardianError {
         return GuardianError(string: invalidEnrollmentUriMessage)
+    }
+
+    static var invalidNotificationActionIdentifier: GuardianError {
+        return GuardianError(string: invalidNotificationActionIdentifierMessage)
     }
 }

--- a/Guardian/Notification.swift
+++ b/Guardian/Notification.swift
@@ -22,7 +22,9 @@
 
 import Foundation
 
-private let AuthenticationCategory = "com.auth0.notification.authentication"
+public let AuthenticationCategory = "com.auth0.notification.authentication"
+let acceptActionIdentifier: String = "\(AuthenticationCategory).accept"
+let rejectActionIdentifier: String = "\(AuthenticationCategory).reject"
 
 /**
  A Guardian Notification contains data about an authentication request.

--- a/GuardianApp/AppDelegate.swift
+++ b/GuardianApp/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         {
             Guardian
                 .authentication(forDomain: AppDelegate.guardianDomain, andEnrollment: enrollment)
-                .handleAction(withIdentifier: identifier, andNotification: notification)
+                .handleAction(withIdentifier: identifier, notification: notification)
                 .start { _ in
                     completionHandler()
             }

--- a/GuardianApp/AppDelegate.swift
+++ b/GuardianApp/AppDelegate.swift
@@ -36,10 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
 
         // Set up push notifications
-        let notificationTypes: UIUserNotificationType = [UIUserNotificationType.alert, UIUserNotificationType.badge, UIUserNotificationType.sound]
-        let pushNotificationSettings = UIUserNotificationSettings(types: notificationTypes, categories: nil)
-        application.registerUserNotificationSettings(pushNotificationSettings)
-        application.registerForRemoteNotifications()
+        Guardian.registerForRemoteNotifications(application)
 
         return true
     }
@@ -65,6 +62,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let notificationController = rootController?.storyboard?.instantiateViewController(withIdentifier: "NotificationView") as! NotificationController
             notificationController.notification = notification
             rootController?.present(notificationController, animated: true, completion: nil)
+        }
+    }
+
+    func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], withResponseInfo responseInfo: [AnyHashable : Any], completionHandler: @escaping () -> Void) {
+        // when the app has been activated by the user selecting an action from a remote notification
+        print("identifier: \(identifier), userInfo: \(userInfo)")
+
+        if let notification = Guardian.notification(from: userInfo),
+            let enrollment = AppDelegate.enrollment,
+            let identifier = identifier
+        {
+            Guardian
+                .authentication(forDomain: AppDelegate.guardianDomain, andEnrollment: enrollment)
+                .handleAction(withIdentifier: identifier, andNotification: notification)
+                .start { _ in
+                    completionHandler()
+            }
+        } else {
+            completionHandler()
         }
     }
 

--- a/GuardianApp/AppDelegate.swift
+++ b/GuardianApp/AppDelegate.swift
@@ -36,7 +36,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
 
         // Set up push notifications
-        Guardian.registerForRemoteNotifications(application)
+        let category = Guardian.categoryForNotification(withAcceptTitle: NSLocalizedString("Allow", comment: "Accept Guardian authentication request"),
+                                                        rejectTitle: NSLocalizedString("Deny", comment: "Reject Guardian authentication request"))
+        let notificationTypes: UIUserNotificationType = [.badge, .sound]
+        let pushNotificationSettings = UIUserNotificationSettings(types: notificationTypes, categories: [category])
+        application.registerUserNotificationSettings(pushNotificationSettings)
+        application.registerForRemoteNotifications()
 
         return true
     }

--- a/GuardianTests/AuthenticationSpec.swift
+++ b/GuardianTests/AuthenticationSpec.swift
@@ -201,9 +201,6 @@ class AuthenticationSpec: QuickSpec {
 
         describe("handleAction") {
 
-            let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
-            let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
-
             it("should allow when identifier is com.auth0.notification.authentication.accept") {
                 stub(condition: isResolveTransaction(domain: Domain)
                     && hasBearerToken(ValidTransactionToken)) { req in
@@ -212,6 +209,8 @@ class AuthenticationSpec: QuickSpec {
                         }
                         return errorResponse(statusCode: 401, errorCode: "invalid_token", message: "Invalid challenge_response")
                     }.name = "Checking challenge_response"
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
                         .handleAction(withIdentifier: "com.auth0.notification.authentication.accept", notification: notification)
@@ -230,6 +229,8 @@ class AuthenticationSpec: QuickSpec {
                         }
                         return errorResponse(statusCode: 401, errorCode: "invalid_token", message: "Invalid challenge_response")
                     }.name = "Checking challenge_response"
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
                         .handleAction(withIdentifier: "com.auth0.notification.authentication.reject", notification: notification)
@@ -241,6 +242,8 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should fail when identifier is not valid") {
+                let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+                let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
                 waitUntil(timeout: Timeout) { done in
                     Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
                         .handleAction(withIdentifier: "com.auth0.notification.authentication.something", notification: notification)

--- a/GuardianTests/AuthenticationSpec.swift
+++ b/GuardianTests/AuthenticationSpec.swift
@@ -198,6 +198,59 @@ class AuthenticationSpec: QuickSpec {
                 }
             }
         }
+
+        describe("handleAction") {
+
+            let enrollment = Enrollment(id: ValidEnrollmentId, userId: ValidUserId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret)
+            let notification = AuthenticationNotification(domain: Domain, enrollmentId: ValidEnrollmentId, transactionToken: ValidTransactionToken, challenge: ValidNotificationChallenge, startedAt: Date(), source: nil, location: nil)
+
+            it("should allow when identifier is com.auth0.notification.authentication.accept") {
+                stub(condition: isResolveTransaction(domain: Domain)
+                    && hasBearerToken(ValidTransactionToken)) { req in
+                        if checkJWT(request: req, accepted: true) {
+                            return successResponse()
+                        }
+                        return errorResponse(statusCode: 401, errorCode: "invalid_token", message: "Invalid challenge_response")
+                    }.name = "Checking challenge_response"
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
+                        .handleAction(withIdentifier: "com.auth0.notification.authentication.accept", notification: notification)
+                        .start { result in
+                            expect(result).to(beSuccess())
+                            done()
+                    }
+                }
+            }
+
+            it("should reject when identifier is com.auth0.notification.authentication.reject") {
+                stub(condition: isResolveTransaction(domain: Domain)
+                    && hasBearerToken(ValidTransactionToken)) { req in
+                        if checkJWT(request: req, accepted: false) {
+                            return successResponse()
+                        }
+                        return errorResponse(statusCode: 401, errorCode: "invalid_token", message: "Invalid challenge_response")
+                    }.name = "Checking challenge_response"
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
+                        .handleAction(withIdentifier: "com.auth0.notification.authentication.reject", notification: notification)
+                        .start { result in
+                            expect(result).to(beSuccess())
+                            done()
+                    }
+                }
+            }
+
+            it("should fail when identifier is not valid") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.authentication(forDomain: Domain, andEnrollment: enrollment)
+                        .handleAction(withIdentifier: "com.auth0.notification.authentication.something", notification: notification)
+                        .start { result in
+                            expect(result).to(haveGuardianError(withErrorCode: "a0.guardian.internal.invalid_notification_action_identifier"))
+                            done()
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -187,6 +187,15 @@ class GuardianSpec: QuickSpec {
                 }
             }
         }
+
+        describe("categoryForNotification(withAcceptTitle:, rejectTitle:)") {
+
+            let category = Guardian.categoryForNotification(withAcceptTitle: "AcceptTitle", rejectTitle: "RejectTitle")
+
+            it("should set correct category identifier") {
+                expect(category.identifier).to(equal("com.auth0.notification.authentication"))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
`Guardian.categoryForNotification(withAcceptTitle:rejectTitle)` should be called on the AppDelegate's `application(:didFinishLaunchingWithOptions)` method.
It creates the category for the notifications, so the user can register the application to handle Guardian remote notifications and it's actions.

`Guardian.Authentication#handleAction(withIdentifier:notification)` is just a helper to handle the actions with accept/reject identifiers. Mostly so the user doesn't have to handle/know our identifiers, and make the common use case easier.

Closes #42 