### PR TITLE
Add support for appliance

### DIFF
--- a/Guardian/Authentication.swift
+++ b/Guardian/Authentication.swift
@@ -144,7 +144,7 @@ struct RSAAuthentication: Authentication {
             var jwtPayload: [String: Any] = [
                 "iat": currentTime,
                 "exp": currentTime + RSAAuthentication.challengeResponseExpiresInSecs,
-                "aud": self.api.baseUrl.absoluteString,
+                "aud": self.api.baseUrl.appendingPathComponent("api/resolve-transaction").absoluteString,
                 "iss": self.enrollment.deviceIdentifier,
                 "sub": challenge,
                 "auth0_guardian_method": "push",

--- a/GuardianTests/APIClientSpec.swift
+++ b/GuardianTests/APIClientSpec.swift
@@ -30,7 +30,7 @@ class APIClientSpec: QuickSpec {
     
     override func spec() {
         
-        let client = APIClient(baseUrl: URL(string: "https://\(Domain)/")!, session: URLSession.shared)
+        let client = APIClient(baseUrl: ValidURL, session: URLSession.shared)
         
         beforeEach {
             stub(condition: { _ in return true }) { _ in
@@ -45,7 +45,7 @@ class APIClientSpec: QuickSpec {
         describe("enroll") {
 
             beforeEach {
-                stub(condition: isMobileEnroll(domain: Domain)
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
                     && hasTicketAuth(ValidTransactionId)
                     && hasAtLeast([
                         "identifier": ValidDeviceIdentifier,
@@ -100,14 +100,14 @@ class APIClientSpec: QuickSpec {
         describe("resolve-transaction") {
 
             beforeEach {
-                stub(condition: isResolveTransaction(domain: Domain)) { _ in
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)) { _ in
                     return errorResponse(statusCode: 404, errorCode: "invalid_token", message: "Invalid transaction token")
                     }.name = "Missing authentication"
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)) { req in
                         return errorResponse(statusCode: 401, errorCode: "invalid_challenge", message: "Invalid challenge_response")
                     }.name = "Invalid challenge_response"
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)
                     && hasAtLeast([
                         "challenge_response": ValidChallengeResponse
@@ -153,14 +153,14 @@ class APIClientSpec: QuickSpec {
         describe("delete enrollment") {
             
             beforeEach {
-                stub(condition: isDeleteEnrollment(domain: Domain)) { _ in
+                stub(condition: isDeleteEnrollment(baseUrl: ValidURL)) { _ in
                     return errorResponse(statusCode: 404, errorCode: "invalid_token", message: "Invalid transaction token")
                     }.name = "Missing authentication"
-                stub(condition: isDeleteEnrollment(domain: Domain)
+                stub(condition: isDeleteEnrollment(baseUrl: ValidURL)
                     && hasBearerToken(ValidEnrollmentToken)) { _ in
                         return errorResponse(statusCode: 404, errorCode: "enrollment_not_found", message: "Enrollment not found")
                     }.name = "Enrollment not found"
-                stub(condition: isDeleteEnrollment(domain: Domain, enrollmentId: ValidEnrollmentId)
+                stub(condition: isDeleteEnrollment(baseUrl: ValidURL, enrollmentId: ValidEnrollmentId)
                     && hasBearerToken(ValidEnrollmentToken)) { _ in
                         return successResponse()
                     }.name = "Valid delete enrollment"
@@ -206,14 +206,14 @@ class APIClientSpec: QuickSpec {
         describe("update enrollment") {
             
             beforeEach {
-                stub(condition: isUpdateEnrollment(domain: Domain)) { _ in
+                stub(condition: isUpdateEnrollment(baseUrl: ValidURL)) { _ in
                     return errorResponse(statusCode: 404, errorCode: "invalid_token", message: "Invalid transaction token")
                     }.name = "Missing authentication"
-                stub(condition: isUpdateEnrollment(domain: Domain)
+                stub(condition: isUpdateEnrollment(baseUrl: ValidURL)
                     && hasBearerToken(ValidEnrollmentToken)) { _ in
                         return errorResponse(statusCode: 404, errorCode: "enrollment_not_found", message: "Enrollment not found")
                     }.name = "Enrollment not found"
-                stub(condition: isUpdateEnrollment(domain: Domain, enrollmentId: ValidEnrollmentId)
+                stub(condition: isUpdateEnrollment(baseUrl: ValidURL, enrollmentId: ValidEnrollmentId)
                     && hasBearerToken(ValidEnrollmentToken)) { req in
                         let payload = req.a0_payload
                         let pushCredentials = payload?["push_credentials"] as? [String: String]

--- a/GuardianTests/AuthenticationSpec.swift
+++ b/GuardianTests/AuthenticationSpec.swift
@@ -45,10 +45,10 @@ class AuthenticationSpec: QuickSpec {
         describe("allow with RSA") {
 
             beforeEach {
-                stub(condition: isResolveTransaction(domain: Domain)) { _ in
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)) { _ in
                     return errorResponse(statusCode: 404, errorCode: "invalid_token", message: "Invalid transaction token")
                     }.name = "Missing authentication"
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)) { req in
                         if checkJWT(request: req, accepted: true) {
                             return successResponse()
@@ -113,10 +113,10 @@ class AuthenticationSpec: QuickSpec {
         describe("reject with RSA") {
 
             beforeEach {
-                stub(condition: isResolveTransaction(domain: Domain)) { _ in
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)) { _ in
                     return errorResponse(statusCode: 404, errorCode: "invalid_token", message: "Invalid transaction token")
                     }.name = "Missing authentication"
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)) { req in
                         if checkJWT(request: req, accepted: false, reason: RejectReason) {
                             return successResponse()
@@ -126,7 +126,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("without reason should succeed when notification and enrollment is valid") {
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)) { req in
                         if checkJWT(request: req, accepted: false) {
                             return successResponse()
@@ -202,7 +202,7 @@ class AuthenticationSpec: QuickSpec {
         describe("handleAction") {
 
             it("should allow when identifier is com.auth0.notification.authentication.accept") {
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)) { req in
                         if checkJWT(request: req, accepted: true) {
                             return successResponse()
@@ -222,7 +222,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should reject when identifier is com.auth0.notification.authentication.reject") {
-                stub(condition: isResolveTransaction(domain: Domain)
+                stub(condition: isResolveTransaction(baseUrl: ValidURL)
                     && hasBearerToken(ValidTransactionToken)) { req in
                         if checkJWT(request: req, accepted: false) {
                             return successResponse()
@@ -263,7 +263,7 @@ func checkJWT(request: URLRequest, accepted: Bool, reason: String? = nil, challe
         let challengeResponse = payload["challenge_response"] as? String,
         let claims = try? JWT.verify(string: challengeResponse, publicKey: ValidRSAPublicKey.ref!),
         let aud = claims["aud"] as? String,
-        aud == "https://\(Domain)",
+        aud == "https://tenant.guardian.auth0.com/also/works/in/appliance/api/resolve-transaction",
         let sub = claims["sub"] as? String,
         sub == challenge,
         let iss = claims["iss"] as? String,

--- a/GuardianTests/Constants.swift
+++ b/GuardianTests/Constants.swift
@@ -24,10 +24,10 @@ import Foundation
 
 @testable import Guardian
 
-let Domain = "tenant.guardian.auth0.com"
+let Domain = "tenant.guardian.auth0.com/also/works/in/appliance/"
 let Timeout: TimeInterval = 2
 
-let ValidURL = URL(string: "https://\(Domain)/")!
+let ValidURL = URL(string: "https://\(Domain)")!
 let ValidTransactionId = UUID().uuidString
 let ValidEnrollmentId = UUID().uuidString
 let ValidEnrollmentToken = UUID().uuidString

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -79,7 +79,7 @@ class GuardianSpec: QuickSpec {
         describe("enroll(forDomain:, session:, withUri:, notificationToken:)") {
 
             beforeEach {
-                stub(condition: isMobileEnroll(domain: Domain)
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
                     && hasTicketAuth(ValidTransactionId)
                     && hasAtLeast([
                         "identifier": Enrollment.defaultDeviceIdentifier,
@@ -97,7 +97,7 @@ class GuardianSpec: QuickSpec {
                         "n": "AKZpUNxEdyiAcvJEI-qxsGEm-96lcPh9Qtu0LWU9OY2oWhDIX_ZKsHYXbqpPyqXUYv4IcvK9X4XnuVvMqxGWxK3kARuAQgjOE-naOl5ed4FNCTTs58e7Jg32bILQqY2539MLomObKloFqAeyA5EMKv1f3pAT2dife5uN7QUz-ifaTGJlP6UCRjfY8TTbbpvFvOHfZmVptfSmq94typg4u2yUgMGRl0vTCkz35e-ox1Y7GfeIkBGQUzY6GFFXPxOct_71a6KtzXxOnYeI9HX0WYX8-hyULasv3RzTLteHIU70Bczfh7hUVGtLMBBLDY0KhZqkZAfrDA38NZm4z932-OqXJ1nVx0MiT9Kt73jy8Gp78CO7t9lJcml3vW1pW-p7swZan8Bs5u6E9Ntch1LUZitxq-f51FsCc478xDp-Yb51FFN-3MPVgW_orXfq_cuOvbQVtr2RciKHTUs4EOfxgj27X0Yzymfi33r9xtJIwUQyoXEhXN6GpKnFnQQvQtSiyhWMGTEbhN8Lu7EDJOD5E4OcZ51J_JveOtg5Y35InjQGcwcHSGzwhrbv3YUIWiXM_w6tBYCJMKC12Myb84D7mavDKhwP3iZ7LBC71kS6Fi53MkM9YIlIGb1OL_tMXDLjKkAPk7JyABITRvE_IbK1ag93UL5G2lrIAgkGNBJIx3mV"
                         ])) { _ in
                             return enrollResponse(enrollmentId: ValidEnrollmentId,
-                                                  url: ValidURL.host,
+                                                  url: ValidURL.absoluteString,
                                                   userId: ValidUserId,
                                                   issuer: ValidIssuer,
                                                   token: ValidEnrollmentToken,
@@ -155,7 +155,7 @@ class GuardianSpec: QuickSpec {
             }
 
             it("should fail when enrollment transaction is invalid") {
-                stub(condition: isMobileEnroll(domain: Domain)
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
                     && !hasTicketAuth(ValidTransactionId)) { _ in
                         return errorResponse(statusCode: 404, errorCode: "enrollment_transaction_not_found", message: "Not found")
                     }.name = "Enrollment transaction not found"
@@ -170,7 +170,7 @@ class GuardianSpec: QuickSpec {
             }
 
             it("should fail when enrollment transaction is valid but response is invalid") {
-                stub(condition: isMobileEnroll(domain: Domain)
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
                     && hasTicketAuth(ValidTransactionId)) { _ in
                         let json = [
                             "notTheRequiredField": "someValue",

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -54,7 +54,18 @@ class GuardianSpec: QuickSpec {
                 let session = URLSession(configuration: .ephemeral)
                 expect(Guardian.api(forDomain: "samples.guardian.auth0.com", session: session)).toNot(beNil())
             }
+        }
 
+        describe("api(url:, session:)") {
+
+            it("should return api with url only") {
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!)).toNot(beNil())
+            }
+
+            it("should return api with url and URLSession") {
+                let session = URLSession(configuration: .ephemeral)
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!, session: session)).toNot(beNil())
+            }
         }
 
         describe("authentication(forDomain:, session:)") {
@@ -73,7 +84,20 @@ class GuardianSpec: QuickSpec {
                 let session = URLSession(configuration: .ephemeral)
                 expect(Guardian.authentication(forDomain: "samples.guardian.auth0.com", andEnrollment: enrollment, session: session)).toNot(beNil())
             }
-            
+        }
+
+        describe("authentication(url:, session:)") {
+
+            let enrollment = Enrollment(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: ValidRSAPrivateKey, base32Secret: "SECRET")
+
+            it("should return authentication with http url") {
+                expect(Guardian.authentication(url: URL(string: "https://samples.guardian.auth0.com")!, andEnrollment: enrollment)).toNot(beNil())
+            }
+
+            it("should return authentication with url and URLSession") {
+                let session = URLSession(configuration: .ephemeral)
+                expect(Guardian.authentication(url: URL(string: "https://samples.guardian.auth0.com")!, andEnrollment: enrollment, session: session)).toNot(beNil())
+            }
         }
 
         describe("enroll(forDomain:, session:, withUri:, notificationToken:)") {
@@ -180,6 +204,118 @@ class GuardianSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     Guardian
                         .enroll(forDomain: Domain, usingTicket: ValidTransactionId, notificationToken: ValidNotificationToken, keyPair: ValidRSAKeyPair)
+                        .start { result in
+                            expect(result).to(haveGuardianError(withErrorCode: "a0.guardian.internal.invalid_response"))
+                            done()
+                    }
+                }
+            }
+        }
+
+        describe("enroll(url:, session:, withUri:, notificationToken:)") {
+
+            beforeEach {
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
+                    && hasTicketAuth(ValidTransactionId)
+                    && hasAtLeast([
+                        "identifier": Enrollment.defaultDeviceIdentifier,
+                        "name": Enrollment.defaultDeviceName
+                        ])
+                    && hasField("push_credentials", withParameters: [
+                        "service": ValidNotificationService,
+                        "token": ValidNotificationToken
+                        ])
+                    && hasField("public_key", withParameters: [
+                        "alg": "RS256",
+                        "e": "AQAB",
+                        "use": "sig",
+                        "kty": "RSA",
+                        "n": "AKZpUNxEdyiAcvJEI-qxsGEm-96lcPh9Qtu0LWU9OY2oWhDIX_ZKsHYXbqpPyqXUYv4IcvK9X4XnuVvMqxGWxK3kARuAQgjOE-naOl5ed4FNCTTs58e7Jg32bILQqY2539MLomObKloFqAeyA5EMKv1f3pAT2dife5uN7QUz-ifaTGJlP6UCRjfY8TTbbpvFvOHfZmVptfSmq94typg4u2yUgMGRl0vTCkz35e-ox1Y7GfeIkBGQUzY6GFFXPxOct_71a6KtzXxOnYeI9HX0WYX8-hyULasv3RzTLteHIU70Bczfh7hUVGtLMBBLDY0KhZqkZAfrDA38NZm4z932-OqXJ1nVx0MiT9Kt73jy8Gp78CO7t9lJcml3vW1pW-p7swZan8Bs5u6E9Ntch1LUZitxq-f51FsCc478xDp-Yb51FFN-3MPVgW_orXfq_cuOvbQVtr2RciKHTUs4EOfxgj27X0Yzymfi33r9xtJIwUQyoXEhXN6GpKnFnQQvQtSiyhWMGTEbhN8Lu7EDJOD5E4OcZ51J_JveOtg5Y35InjQGcwcHSGzwhrbv3YUIWiXM_w6tBYCJMKC12Myb84D7mavDKhwP3iZ7LBC71kS6Fi53MkM9YIlIGb1OL_tMXDLjKkAPk7JyABITRvE_IbK1ag93UL5G2lrIAgkGNBJIx3mV"
+                        ])) { _ in
+                            return enrollResponse(enrollmentId: ValidEnrollmentId,
+                                                  url: ValidURL.absoluteString,
+                                                  userId: ValidUserId,
+                                                  issuer: ValidIssuer,
+                                                  token: ValidEnrollmentToken,
+                                                  totpSecret: ValidBase32Secret,
+                                                  totpAlgorithm: ValidAlgorithm,
+                                                  totpDigits: ValidDigits,
+                                                  totpPeriod: ValidPeriod)
+                    }.name = "Valid enrollment"
+            }
+
+            it("should succeed when enrollmentUri is valid") {
+                waitUntil(timeout: Timeout) { done in
+                    let uri = enrollmentUri(withTransactionId: ValidTransactionId, baseUrl: ValidURL.absoluteString, enrollmentId: ValidEnrollmentId, issuer: ValidIssuer, user: ValidUser, secret: ValidBase32Secret, algorithm: ValidAlgorithm, digits: ValidDigits, period: ValidPeriod)
+                    Guardian
+                        .enroll(url: ValidURL, usingUri: uri, notificationToken: ValidNotificationToken, keyPair: ValidRSAKeyPair)
+                        .start { result in
+                            expect(result).to(haveEnrollment(withBaseUrl: ValidURL, enrollmentId: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, issuer: ValidIssuer, userId: ValidUserId, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret, algorithm: ValidAlgorithm, digits: ValidDigits, period: ValidPeriod))
+                            done()
+                    }
+                }
+            }
+
+            it("should succeed when enrollmentTicket is valid") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian
+                        .enroll(url: ValidURL, usingTicket: ValidTransactionId, notificationToken: ValidNotificationToken, keyPair: ValidRSAKeyPair)
+                        .start { result in
+                            expect(result).to(haveEnrollment(withBaseUrl: ValidURL, enrollmentId: ValidEnrollmentId, deviceToken: ValidEnrollmentToken, notificationToken: ValidNotificationToken, issuer: ValidIssuer, userId: ValidUserId, signingKey: ValidRSAPrivateKey, base32Secret: ValidBase32Secret, algorithm: ValidAlgorithm, digits: ValidDigits, period: ValidPeriod))
+                            done()
+                    }
+                }
+            }
+
+            it("should fail when enrollmentUri is invalid") {
+                waitUntil(timeout: Timeout) { done in
+                    let enrollmentUri = "someInvalidEnrollmentUri"
+                    Guardian
+                        .enroll(url: ValidURL, usingUri: enrollmentUri, notificationToken: ValidNotificationToken, keyPair: ValidRSAKeyPair)
+                        .start { result in
+                            expect(result).to(haveGuardianError(withErrorCode: "a0.guardian.internal.invalid_enrollment_uri"))
+                            done()
+                    }
+                }
+            }
+
+            it("should fail when public key is invalid") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian
+                        .enroll(url: ValidURL, usingTicket: ValidTransactionId, notificationToken: ValidNotificationToken, keyPair: RSAKeyPair(publicKey: NonRSAPublicKey, privateKey: ValidRSAPrivateKey))
+                        .start { result in
+                            expect(result).to(haveGuardianError(withErrorCode: "a0.guardian.internal.invalid_public_key"))
+                            done()
+                    }
+                }
+            }
+
+            it("should fail when enrollment transaction is invalid") {
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
+                    && !hasTicketAuth(ValidTransactionId)) { _ in
+                        return errorResponse(statusCode: 404, errorCode: "enrollment_transaction_not_found", message: "Not found")
+                    }.name = "Enrollment transaction not found"
+                waitUntil(timeout: Timeout) { done in
+                    Guardian
+                        .enroll(url: ValidURL, usingTicket: "someInvalidTransactionId", notificationToken: ValidNotificationToken, keyPair: ValidRSAKeyPair)
+                        .start { result in
+                            expect(result).to(haveGuardianError(withErrorCode: "enrollment_transaction_not_found"))
+                            done()
+                    }
+                }
+            }
+
+            it("should fail when enrollment transaction is valid but response is invalid") {
+                stub(condition: isMobileEnroll(baseUrl: ValidURL)
+                    && hasTicketAuth(ValidTransactionId)) { _ in
+                        let json = [
+                            "notTheRequiredField": "someValue",
+                            ]
+                        return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+                    }.name = "Invalid enroll response"
+                waitUntil(timeout: Timeout) { done in
+                    Guardian
+                        .enroll(url: ValidURL, usingTicket: ValidTransactionId, notificationToken: ValidNotificationToken, keyPair: ValidRSAKeyPair)
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: "a0.guardian.internal.invalid_response"))
                             done()


### PR DESCRIPTION
Guardian can work in a path instead of a subdomain, so now you can use an URL instead of domain.
We also use the full url in audience for challenge response.
