### PR TITLE
Make nonCachedSession public in order to be Swift 4.2 compliant

### DIFF
--- a/Guardian/Guardian.swift
+++ b/Guardian/Guardian.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-let nonCachedSession: URLSession =  {
+public let nonCachedSession: URLSession =  {
     let config = URLSessionConfiguration.default
     config.requestCachePolicy = .reloadIgnoringLocalCacheData
     config.urlCache = nil


### PR DESCRIPTION
As mentioned in https://github.com/auth0/Guardian.swift/issues/61 Guardian.swift is not compatible with Swift 4.x, so this commit applies the proposed fix.