### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [0.5.0](https://github.com/auth0/Guardian.swift/tree/0.5.0) (2018-07-19)
+[Full Changelog](https://github.com/auth0/Guardian.swift/compare/0.4.0...0.5.0)
+**Closed issues**
+- Private constants as default arguments - Swift 4 Support [\#61](https://github.com/auth0/Guardian.swift/issues/61)
+
+**Changed**
+- Update to compile with Swift 4 [\#63](https://github.com/auth0/Guardian.swift/pull/63) ([hzalaz](https://github.com/hzalaz))
+
+**Deprecated**
+- Deprecate iOS 9 or older notification code [\#64](https://github.com/auth0/Guardian.swift/pull/64) ([hzalaz](https://github.com/hzalaz))
+
 ## [0.4.0](https://github.com/auth0/Guardian.swift/tree/0.4.0) (2018-06-08)
 [Full Changelog](https://github.com/auth0/Guardian.swift/compare/0.3.1...0.4.0)
 

--- a/Guardian/Info.plist
+++ b/Guardian/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/GuardianApp/Info.plist
+++ b/GuardianApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/GuardianTests/Info.plist
+++ b/GuardianTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Guardian.swift is available through [CocoaPods](http://cocoapods.org).
 To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Guardian', '~> 0.4.0'
+pod 'Guardian', '~> 0.5.0'
 ```
 
 #### Carthage
@@ -44,7 +44,7 @@ pod 'Guardian', '~> 0.4.0'
 In your Cartfile add this line
 
 ```
-github "auth0/Guardian.swift" ~> 0.4.0
+github "auth0/Guardian.swift" ~> 0.5.0
 ```
 
 ## Usage


### PR DESCRIPTION
# Change Log

## [0.5.0](https://github.com/auth0/Guardian.swift/tree/0.5.0) (2018-07-19)
[Full Changelog](https://github.com/auth0/Guardian.swift/compare/0.4.0...0.5.0)
**Closed issues**
- Private constants as default arguments - Swift 4 Support [\#61](https://github.com/auth0/Guardian.swift/issues/61)

**Changed**
- Update to compile with Swift 4 [\#63](https://github.com/auth0/Guardian.swift/pull/63) ([hzalaz](https://github.com/hzalaz))

**Deprecated**
- Deprecate iOS 9 or older notification code [\#64](https://github.com/auth0/Guardian.swift/pull/64) ([hzalaz](https://github.com/hzalaz))