### PR TITLE
Now the session should be configured per request.

### DIFF
--- a/Guardian/APIClient.swift
+++ b/Guardian/APIClient.swift
@@ -25,11 +25,9 @@ import Foundation
 struct APIClient: API {
 
     let baseUrl: URL
-    let session: URLSession
-    
-    init(baseUrl: URL, session: URLSession) {
+
+    init(baseUrl: URL) {
         self.baseUrl = baseUrl
-        self.session = session
     }
 
     func enroll(withTicket enrollmentTicket: String, identifier: String, name: String, notificationToken: String, verificationKey: VerificationKey) -> Request<[String: Any]> {
@@ -49,7 +47,7 @@ struct APIClient: API {
                 ],
                 "public_key": jwk
             ]
-            return Request(session: self.session, method: "POST", url: url, payload: payload, headers: ["Authorization": "Ticket id=\"\(enrollmentTicket)\""])
+            return Request(method: "POST", url: url, payload: payload, headers: ["Authorization": "Ticket id=\"\(enrollmentTicket)\""])
         } catch(let error) {
             return FailedRequest(error: error)
         }
@@ -60,10 +58,10 @@ struct APIClient: API {
             "challenge_response": challengeResponse
         ]
         let url = self.baseUrl.appendingPathComponent("api/resolve-transaction")
-        return Request(session: self.session, method: "POST", url: url, payload: payload, headers: ["Authorization": "Bearer \(transactionToken)"])
+        return Request(method: "POST", url: url, payload: payload, headers: ["Authorization": "Bearer \(transactionToken)"])
     }
 
     func device(forEnrollmentId id: String, token: String) -> DeviceAPI {
-        return DeviceAPIClient(baseUrl: baseUrl, session: session, id: id, token: token)
+        return DeviceAPIClient(baseUrl: baseUrl, id: id, token: token)
     }
 }

--- a/Guardian/DeviceAPIClient.swift
+++ b/Guardian/DeviceAPIClient.swift
@@ -23,19 +23,16 @@
 import Foundation
 
 struct DeviceAPIClient: DeviceAPI {
-    
-    let session: URLSession
     let url: URL
     let token: String
     
-    init(baseUrl: URL, session: URLSession, id: String, token: String) {
+    init(baseUrl: URL, id: String, token: String) {
         self.url = baseUrl.appendingPathComponent("api/device-accounts/\(id)")
-        self.session = session
         self.token = token
     }
     
     func delete() -> Request<Void> {
-        return Request(session: session, method: "DELETE", url: url, headers: ["Authorization": "Bearer \(token)"])
+        return Request(method: "DELETE", url: url, headers: ["Authorization": "Bearer \(token)"])
     }
     
     func update(deviceIdentifier identifier: String? = nil, name: String? = nil, notificationToken: String? = nil) -> Request<[String: Any]> {
@@ -48,6 +45,6 @@ struct DeviceAPIClient: DeviceAPI {
                 "token": notificationToken
             ]
         }
-        return Request(session: session, method: "PATCH", url: url, payload: payload, headers: ["Authorization": "Bearer \(token)"])
+        return Request(method: "PATCH", url: url, payload: payload, headers: ["Authorization": "Bearer \(token)"])
     }
 }

--- a/Guardian/FailedRequest.swift
+++ b/Guardian/FailedRequest.swift
@@ -28,7 +28,7 @@ class FailedRequest<T>: Request<T> {
 
     init(error: Error) {
         self.error = error
-        super.init(session: URLSession.shared, method: "GET", url: URL(string: "auth0.com")!)
+        super.init(method: "GET", url: URL(string: "auth0.com")!)
     }
 
     override func start(callback: @escaping (Result<T>) -> ()) {

--- a/Guardian/Request.swift
+++ b/Guardian/Request.swift
@@ -22,20 +22,28 @@
 
 import Foundation
 
+/// Default URLSession used to send requests to Guardian API.
+private let defaultURLSession: URLSession =  {
+    let config = URLSessionConfiguration.default
+    config.requestCachePolicy = .reloadIgnoringLocalCacheData
+    config.urlCache = nil
+
+    return URLSession.init(configuration: config)
+}()
+
 /**
  An asynchronous HTTP request
  */
 public class Request<T>: Requestable {
 
-    let session: URLSession
+    var session: URLSession = defaultURLSession
     let method: String
     let url: URL
     let payload: [String: Any]?
     let headers: [String: String]
     var hooks: Hooks
     
-    init(session: URLSession, method: String, url: URL, payload: [String: Any]? = nil, headers: [String: String]? = nil) {
-        self.session = session
+    init(method: String, url: URL, payload: [String: Any]? = nil, headers: [String: String]? = nil) {
         self.method = method
         self.url = url
         self.payload = payload
@@ -83,8 +91,13 @@ public class Request<T>: Requestable {
     ///   - response: closure called with response and data
     ///   - error: closure called with network error
     /// - Returns: itself for chaining
-    public func on(request: RequestHook? = nil, response: ResponseHook? = nil, error: ErrorHook? = nil) -> Request {
+    public func on(request: RequestHook? = nil, response: ResponseHook? = nil, error: ErrorHook? = nil) -> Request<T> {
         self.hooks = Hooks(request: request ?? self.hooks.request, response: response ?? self.hooks.response, error: error ?? self.hooks.error)
+        return self
+    }
+
+    public func using(session: URLSession) -> Request<T> {
+        self.session = session
         return self
     }
 

--- a/GuardianTests/APIClientSpec.swift
+++ b/GuardianTests/APIClientSpec.swift
@@ -30,7 +30,7 @@ class APIClientSpec: QuickSpec {
     
     override func spec() {
         
-        let client = APIClient(baseUrl: ValidURL, session: Guardian.defaultURLSession)
+        let client = APIClient(baseUrl: ValidURL)
         let keys = Keys.shared
         let signingKey = try! DataRSAPrivateKey(data: keys.privateKey)
         let verificationKey = try! signingKey.verificationKey()

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -40,7 +40,7 @@ class GuardianSpec: QuickSpec {
             OHHTTPStubs.removeAllStubs()
         }
 
-        describe("api(forDomain:, session:)") {
+        describe("api(forDomain:)") {
 
             it("should return api with domain only") {
                 expect(Guardian.api(forDomain: "samples.guardian.auth0.com")).toNot(beNil())
@@ -49,22 +49,12 @@ class GuardianSpec: QuickSpec {
             it("should return api with http url") {
                 expect(Guardian.api(forDomain: "https://samples.guardian.auth0.com")).toNot(beNil())
             }
-
-            it("should return api with domain and URLSession") {
-                let session = URLSession(configuration: .ephemeral)
-                expect(Guardian.api(forDomain: "samples.guardian.auth0.com", session: session)).toNot(beNil())
-            }
         }
 
-        describe("api(url:, session:)") {
+        describe("api(url:)") {
 
             it("should return api with url only") {
                 expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!)).toNot(beNil())
-            }
-
-            it("should return api with url and URLSession") {
-                let session = URLSession(configuration: .ephemeral)
-                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!, session: session)).toNot(beNil())
             }
         }
 
@@ -79,28 +69,18 @@ class GuardianSpec: QuickSpec {
             it("should return authentication with http url") {
                 expect(Guardian.authentication(forDomain: "https://samples.guardian.auth0.com", device: enrollment)).toNot(beNil())
             }
-
-            it("should return authentication with domain and URLSession") {
-                let session = URLSession(configuration: .ephemeral)
-                expect(Guardian.authentication(forDomain: "samples.guardian.auth0.com", device: enrollment, session: session)).toNot(beNil())
-            }
         }
 
-        describe("authentication(url:, session:)") {
+        describe("authentication(url:)") {
 
             let enrollment = Enrollment(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: try! DataRSAPrivateKey.new(), base32Secret: "SECRET")
 
             it("should return authentication with http url") {
                 expect(Guardian.authentication(url: URL(string: "https://samples.guardian.auth0.com")!, device: enrollment)).toNot(beNil())
             }
-
-            it("should return authentication with url and URLSession") {
-                let session = URLSession(configuration: .ephemeral)
-                expect(Guardian.authentication(url: URL(string: "https://samples.guardian.auth0.com")!, device: enrollment, session: session)).toNot(beNil())
-            }
         }
 
-        describe("enroll(forDomain:, session:, withUri:, notificationToken:)") {
+        describe("enroll(forDomain:, withUri:, notificationToken:)") {
 
             let keys = Keys.shared
 

--- a/GuardianTests/RequestSpec.swift
+++ b/GuardianTests/RequestSpec.swift
@@ -38,7 +38,8 @@ class RequestSpec: QuickSpec {
             it("should set url") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: nil, error: nil)
-                    Request<Void>(session: session, method: "PATCH", url: ValidURL)
+                    Request<Void>(method: "PATCH", url: ValidURL)
+                        .using(session: session)
                         .start { _ in
                             let request = session.a0_request!
                             expect(request.url).to(equal(ValidURL))
@@ -50,7 +51,8 @@ class RequestSpec: QuickSpec {
             it("should set method") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: nil, error: nil)
-                    Request<Void>(session: session, method: "PATCH", url: ValidURL)
+                    Request<Void>(method: "PATCH", url: ValidURL)
+                        .using(session: session)
                         .start { _ in
                             let request = session.a0_request!
                             expect(request.httpMethod).to(equal("PATCH"))
@@ -67,7 +69,8 @@ class RequestSpec: QuickSpec {
                         "someOtherField": "someOtherValue"
                     ]
                     let serializedPayload = try? JSONSerialization.data(withJSONObject: payload, options: [])
-                    Request<Void>(session: session, method: "PATCH", url: ValidURL, payload: payload)
+                    Request<Void>(method: "PATCH", url: ValidURL, payload: payload)
+                        .using(session: session)
                         .start { _ in
                             let request = session.a0_request!
                             expect(request.httpBody).to(equal(serializedPayload))
@@ -81,7 +84,8 @@ class RequestSpec: QuickSpec {
                 it("for Content-Type") {
                     waitUntil(timeout: Timeout) { done in
                         let session = MockNSURLSession(data: nil, response: nil, error: nil)
-                        Request<Void>(session: session, method: "PATCH", url: ValidURL, payload: ["key": "value"])
+                        Request<Void>(method: "PATCH", url: ValidURL, payload: ["key": "value"])
+                            .using(session: session)
                             .start { _ in
                                 let request = session.a0_request!
                                 expect(request.value(forHTTPHeaderField: "Content-Type")).to(equal("application/json"))
@@ -93,7 +97,8 @@ class RequestSpec: QuickSpec {
                 it("for Auth0-Client") {
                     waitUntil(timeout: Timeout) { done in
                         let session = MockNSURLSession(data: nil, response: nil, error: nil)
-                        Request<Void>(session: session, method: "PATCH", url: ValidURL)
+                        Request<Void>(method: "PATCH", url: ValidURL)
+                            .using(session: session)
                             .start { _ in
                                 let request = session.a0_request!
                                 let encodedLibInfo = request.value(forHTTPHeaderField: "Auth0-Client")
@@ -116,7 +121,8 @@ class RequestSpec: QuickSpec {
             it("should set custom headers") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: nil, error: nil)
-                    Request<Void>(session: session, method: "PATCH", url: ValidURL, headers: ["SomeHeaderName": "SomeHeaderValue"])
+                    Request<Void>(method: "PATCH", url: ValidURL, headers: ["SomeHeaderName": "SomeHeaderValue"])
+                        .using(session: session)
                         .start { _ in
                             let request = session.a0_request!
                             expect(request.value(forHTTPHeaderField: "SomeHeaderName")).to(equal("SomeHeaderValue"))
@@ -131,7 +137,8 @@ class RequestSpec: QuickSpec {
             it("should call request hook") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: nil, error: NSError(domain: "auth0.com", code: ErrorCode, userInfo: nil))
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .on(request: { request in
                             done()
                         })
@@ -144,7 +151,8 @@ class RequestSpec: QuickSpec {
                     let messageData = "Success!!".data(using: .utf8)
                     let httpResponse = HTTPURLResponse(url: ValidURL, statusCode: 200, httpVersion: nil, headerFields: nil)
                     let session = MockNSURLSession(data: messageData, response: httpResponse, error: nil)
-                    Request<String>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<String>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .on(response: { response, data in
                             expect(response).to(be(httpResponse))
                             done()
@@ -156,7 +164,8 @@ class RequestSpec: QuickSpec {
             it("should call error hook") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: nil, error: NSError(domain: "auth0.com", code: ErrorCode, userInfo: nil))
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .on(error: { error in
                             done()
                         })
@@ -170,7 +179,8 @@ class RequestSpec: QuickSpec {
             it("should fail with forwarded error when there is an NSError") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: nil, error: NSError(domain: "auth0.com", code: ErrorCode, userInfo: nil))
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .start { result in
                             expect(result).to(haveNSError(withErrorCode: ErrorCode))
                             done()
@@ -181,7 +191,8 @@ class RequestSpec: QuickSpec {
             it("should fail with 'invalid response' when the response is not a NSHTTPURLResponse") {
                 waitUntil(timeout: Timeout) { done in
                     let session = MockNSURLSession(data: nil, response: URLResponse(), error: nil)
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: GuardianError.invalidResponse.errorCode))
                             done()
@@ -193,7 +204,8 @@ class RequestSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     let response = HTTPURLResponse(url: ValidURL, statusCode: 404, httpVersion: nil, headerFields: nil)
                     let session = MockNSURLSession(data: nil, response: response, error: nil)
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: GuardianError.invalidResponse.errorCode, andStatusCode: 404))
                             done()
@@ -206,7 +218,8 @@ class RequestSpec: QuickSpec {
                     let response = HTTPURLResponse(url: ValidURL, statusCode: 401, httpVersion: nil, headerFields: nil)
                     let data = Data(base64Encoded: "SomeInvalidJSON", options: [])
                     let session = MockNSURLSession(data: data, response: response, error: nil)
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: GuardianError.invalidResponse.errorCode, andStatusCode: 401))
                             done()
@@ -221,7 +234,8 @@ class RequestSpec: QuickSpec {
                         "errorCode": "SomeErrorCode"
                         ], options: [])
                     let session = MockNSURLSession(data: data, response: response, error: nil)
-                    Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                    Request<Void>(method: ValidMethod, url: ValidURL)
+                        .using(session: session)
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: "SomeErrorCode", andStatusCode: 401))
                             done()
@@ -235,7 +249,8 @@ class RequestSpec: QuickSpec {
                     waitUntil(timeout: Timeout) { done in
                         let response = HTTPURLResponse(url: ValidURL, statusCode: 201, httpVersion: nil, headerFields: nil)
                         let session = MockNSURLSession(data: nil, response: response, error: nil)
-                        Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                        Request<Void>(method: ValidMethod, url: ValidURL)
+                            .using(session: session)
                             .start { result in
                                 expect(result).to(beSuccess())
                                 done()
@@ -251,7 +266,8 @@ class RequestSpec: QuickSpec {
                         ]
                         let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
                         let session = MockNSURLSession(data: data, response: response, error: nil)
-                        Request<Void>(session: session, method: ValidMethod, url: ValidURL)
+                        Request<Void>(method: ValidMethod, url: ValidURL)
+                            .using(session: session)
                             .start { result in
                                 expect(result).to(beSuccess())
                                 done()
@@ -270,7 +286,8 @@ class RequestSpec: QuickSpec {
                         ]
                         let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
                         let session = MockNSURLSession(data: data, response: response, error: nil)
-                        Request<[String: String]>(session: session, method: ValidMethod, url: ValidURL)
+                        Request<[String: String]>(method: ValidMethod, url: ValidURL)
+                            .using(session: session)
                             .start { result in
                                 expect(result).to(beSuccess(withData: ["someField": "someValue"]))
                                 done()
@@ -290,7 +307,8 @@ class RequestSpec: QuickSpec {
                         ]
                         let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
                         let session = MockNSURLSession(data: data, response: response, error: nil)
-                        Request<[String: String]>(session: session, method: ValidMethod, url: ValidURL)
+                        Request<[String: String]>(method: ValidMethod, url: ValidURL)
+                            .using(session: session)
                             .start { result in
                                 expect(result).to(haveGuardianError(withErrorCode: GuardianError.invalidResponse.errorCode, andStatusCode: 201))
                                 done()


### PR DESCRIPTION
Added new method `using(session:)` to `Request` to allow using a different
session than the default.

The default session still is on without cache and do not stores any sensitive
data