### PR TITLE
Remove Xcode 12.4 workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,14 @@ jobs:
 
     # Specify the Xcode version to use.
     macos:
-      xcode: "12.4.0"
+      xcode: "12.5.0"
     working_directory: /Users/distiller/project
     environment:
       - LC_ALL: en_US.UTF-8
       - LANG: en_US.UTF-8
       - FL_OUTPUT_DIR: output
       - FASTLANE_EXPLICIT_OPEN_SIMULATOR: 2
-        HOMEBREW_NO_AUTO_UPDATE: 1
+      - HOMEBREW_NO_AUTO_UPDATE: 1
 
     # Define the steps required to build the project.
     steps:
@@ -51,8 +51,8 @@ jobs:
       # Download iOS Dependencies
       - restore_cache:
           keys:
-            - guardian.swift-carthage-v1-{{ checksum "Cartfile.resolved" }}
-            - guardian.swift-carthage-v1-
+            - guardian.swift-carthage-v2-{{ checksum "Cartfile.resolved" }}
+            - guardian.swift-carthage-v2-
 
       # Run tests.
       - run:
@@ -65,7 +65,7 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash) -J 'Guardian'
 
       - save_cache:
-          key: guardian.swift-carthage-v1-{{ checksum "Cartfile.resolved" }}
+          key: guardian.swift-carthage-v2-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage/Build
 

--- a/Guardian.xcodeproj/project.pbxproj
+++ b/Guardian.xcodeproj/project.pbxproj
@@ -44,12 +44,6 @@
 		5C19E567266515DF00F167EC /* Nimble.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C19E561266515D000F167EC /* Nimble.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C19E568266515DF00F167EC /* OHHTTPStubs.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C19E562266515D100F167EC /* OHHTTPStubs.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C19E569266515DF00F167EC /* Quick.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C19E563266515D100F167EC /* Quick.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5C19E56D266571C400F167EC /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C19E561266515D000F167EC /* Nimble.xcframework */; };
-		5C19E56E266571C400F167EC /* OHHTTPStubs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C19E562266515D100F167EC /* OHHTTPStubs.xcframework */; };
-		5C19E56F266571C400F167EC /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C19E563266515D100F167EC /* Quick.xcframework */; };
-		5C19E570266571C800F167EC /* Nimble.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C19E561266515D000F167EC /* Nimble.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5C19E571266571C800F167EC /* OHHTTPStubs.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C19E562266515D100F167EC /* OHHTTPStubs.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5C19E572266571C800F167EC /* Quick.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C19E563266515D100F167EC /* Quick.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5F07A58521092C7D00819FA2 /* ClientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F07A58421092C7D00819FA2 /* ClientInfo.swift */; };
 		5F07A58721092F2300819FA2 /* ClientInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F07A58621092F2300819FA2 /* ClientInfoSpec.swift */; };
 		5F07A589210A57C200819FA2 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F07A588210A57C200819FA2 /* Events.swift */; };
@@ -143,9 +137,6 @@
 			files = (
 				23FE50841D949EC400407A1D /* Guardian.framework in Embed Frameworks */,
 				5C19E55E266515A600F167EC /* SimpleKeychain.xcframework in Embed Frameworks */,
-				5C19E570266571C800F167EC /* Nimble.xcframework in Embed Frameworks */,
-				5C19E571266571C800F167EC /* OHHTTPStubs.xcframework in Embed Frameworks */,
-				5C19E572266571C800F167EC /* Quick.xcframework in Embed Frameworks */,
 				5C19E560266515A600F167EC /* QRCodeReader.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -294,9 +285,6 @@
 				23FE50831D949EC400407A1D /* Guardian.framework in Frameworks */,
 				5C19E55D266515A600F167EC /* SimpleKeychain.xcframework in Frameworks */,
 				5C19E55F266515A600F167EC /* QRCodeReader.xcframework in Frameworks */,
-				5C19E56D266571C400F167EC /* Nimble.xcframework in Frameworks */,
-				5C19E56E266571C400F167EC /* OHHTTPStubs.xcframework in Frameworks */,
-				5C19E56F266571C400F167EC /* Quick.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Description

Xcode 12.5 has just been made available on CircleCI. This PR removes the previous workaround for Xcode 12.4.

### References

https://discuss.circleci.com/t/xcode-12-5-release/40265

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
