### PR TITLE
Use auth0/SimpleKeychain version 0.12.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
 
     # Specify the Xcode version to use.
     macos:
-      xcode: "12.5.0"
+      xcode: "12.5.1"
     working_directory: /Users/distiller/project
     environment:
       - LC_ALL: en_US.UTF-8

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -2,4 +2,4 @@ github "AliSoftware/OHHTTPStubs" ~> 8.0
 github "Quick/Nimble" ~> 9.2
 github "Quick/Quick" ~> 2.2
 github "yannickl/QRCodeReader.swift" >= 8.2.0
-github "auth0/SimpleKeychain"
+github "auth0/SimpleKeychain" == 0.12.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v9.2.0"
+github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v2.2.1"
 github "auth0/SimpleKeychain" "0.12.2"
 github "yannickl/QRCodeReader.swift" "10.1.1"


### PR DESCRIPTION
### Description
auth0/SimpleKeychain evolved and dropped support for swift 4.
Currently, the demo app fails to compile because `carthage` resolves auth0/SimpleKeychain with version 1.0.0.
The demo app was designed to work with auth0/SimpleKeychain version 0.12.2, yet it was not explicitly set.
We will have to integrate the latest version eventually, but by that time, this fix should do.

