### PR TITLE
Remove unsafe Swift code from OTP code generation

### DIFF
--- a/Guardian/Generators/OneTimePasswordGenerator.swift
+++ b/Guardian/Generators/OneTimePasswordGenerator.swift
@@ -82,11 +82,12 @@ struct OneTimePasswordGenerator: TOTP, HOTP {
         var c = UInt64(counter).bigEndian
         let buffer = Data(bytes: &c, count: MemoryLayout<UInt64>.size);
         let digestData = hmac.sign(buffer)
+        let length = MemoryLayout<UInt32>.size
         guard let offset = digestData.last.map({ Int($0 & 0x0f) }),
-              (offset + 4) < digestData.count else {
-            return -1
+              (offset + length) < digestData.count else {
+            return 0
         }
-        var hash = digestData.dropFirst(offset).prefix(4).reduce(0, { $0 << 8 | UInt32($1) })
+        var hash = digestData.dropFirst(offset).prefix(length).reduce(0, { $0 << 8 | UInt32($1) })
         hash &= 0x7fffffff
         hash = hash % UInt32(pow(10, Float(self.parameters.digits)))
         return Int(hash)

--- a/Guardian/Generators/OneTimePasswordGenerator.swift
+++ b/Guardian/Generators/OneTimePasswordGenerator.swift
@@ -82,17 +82,13 @@ struct OneTimePasswordGenerator: TOTP, HOTP {
         var c = UInt64(counter).bigEndian
         let buffer = Data(bytes: &c, count: MemoryLayout<UInt64>.size);
         let digestData = hmac.sign(buffer)
-        let hash = digestData.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> UInt32 in
-            let last = bytes.advanced(by: hmac.digestLength - 1)
-            let offset = last.pointee & 0x0f
-            let start = bytes.advanced(by: Int(offset))
-            let value = start.withMemoryRebound(to: UInt32.self, capacity: 1) { $0 }
-            var hash = UInt32(bigEndian: value.pointee)
-            hash &= 0x7fffffff
-            hash = hash % UInt32(pow(10, Float(self.parameters.digits)))
-            return hash
+        guard let offset = digestData.last.map({ Int($0 & 0x0f) }),
+              (offset + 4) < digestData.count else {
+            return -1
         }
-
+        var hash = digestData.dropFirst(offset).prefix(4).reduce(0, { $0 << 8 | UInt32($1) })
+        hash &= 0x7fffffff
+        hash = hash % UInt32(pow(10, Float(self.parameters.digits)))
         return Int(hash)
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

On iOS 16 we're receiving several exception from the `code(counter:)` function in `OneTimePasswordGenerator`. The exception is related to the block called in the `withUnsafeBytes` function.

This PR aims to replace the code without using unsafe pointers (as suggested by Apple in Swift support forums).

### References

- https://forums.swift.org/t/on-properly-aligned-pointer-for-types-pointee-and-t/61325/3

### Testing

The code is already covered by tests.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
