### PR TITLE
Add support for transaction linking id [SDK-3878]

### DIFF
--- a/Guardian/Authentication/Notification/AuthenticationNotification.swift
+++ b/Guardian/Authentication/Notification/AuthenticationNotification.swift
@@ -57,7 +57,7 @@ struct AuthenticationNotification: Notification, CustomDebugStringConvertible, C
         guard
             let mfa = json["mfa"] as? [String: Any],
             let enrollmentId = mfa["dai"] as? String,
-            let token = mfa["txtkn"] as? String,
+            let transactionToken = mfa["txtkn"] as? String,
             let when = mfa["d"] as? String,
             let startedAt = formatter.date(from: when),
             let domain = mfa["sh"] as? String,
@@ -67,7 +67,7 @@ struct AuthenticationNotification: Notification, CustomDebugStringConvertible, C
         let source = AuthenticationSource(fromJSON: mfa["s"])
         let location = AuthenticationLocation(fromJSON: mfa["l"])
 
-        self.init(domain: domain, enrollmentId: enrollmentId, transactionToken: token, transactionLinkingId: transactionLinkingId, challenge: challenge, startedAt: startedAt, source: source, location: location)
+        self.init(domain: domain, enrollmentId: enrollmentId, transactionToken: transactionToken, transactionLinkingId: transactionLinkingId, challenge: challenge, startedAt: startedAt, source: source, location: location)
     }
 
     var description: String {

--- a/Guardian/Authentication/Notification/AuthenticationNotification.swift
+++ b/Guardian/Authentication/Notification/AuthenticationNotification.swift
@@ -27,15 +27,17 @@ struct AuthenticationNotification: Notification, CustomDebugStringConvertible, C
     let domain: String
     let enrollmentId: String
     let transactionToken: String
+    let transactionLinkingId: String?
     let challenge: String
     let source: Source?
     let location: Location?
     let startedAt: Date
 
-    init(domain: String, enrollmentId: String, transactionToken: String, challenge: String, startedAt: Date, source: Source?, location: Location?) {
+    init(domain: String, enrollmentId: String, transactionToken: String, transactionLinkingId: String? = nil, challenge: String, startedAt: Date, source: Source?, location: Location?) {
         self.domain = domain
         self.enrollmentId = enrollmentId
         self.transactionToken = transactionToken
+        self.transactionLinkingId = transactionLinkingId
         self.challenge = challenge
         self.source = source
         self.location = location
@@ -61,10 +63,11 @@ struct AuthenticationNotification: Notification, CustomDebugStringConvertible, C
             let domain = mfa["sh"] as? String,
             let challenge = mfa["c"] as? String
             else { return nil }
+        let transactionLinkingId = mfa["txlnkid"] as? String
         let source = AuthenticationSource(fromJSON: mfa["s"])
         let location = AuthenticationLocation(fromJSON: mfa["l"])
 
-        self.init(domain: domain, enrollmentId: enrollmentId, transactionToken: token, challenge: challenge, startedAt: startedAt, source: source, location: location)
+        self.init(domain: domain, enrollmentId: enrollmentId, transactionToken: token, transactionLinkingId: transactionLinkingId, challenge: challenge, startedAt: startedAt, source: source, location: location)
     }
 
     var description: String {

--- a/Guardian/Authentication/Notification/Notification.swift
+++ b/Guardian/Authentication/Notification/Notification.swift
@@ -53,6 +53,12 @@ public protocol Notification {
     var transactionToken: String { get }
 
     /**
+     The transaction linking id, used to correlate the notification with
+     an ongoing authorization transaction
+     */
+    var transactionLinkingId: String? { get }
+
+    /**
      The challenge sent by the server. The same challenge, signed, should be 
      sent back when trying to allow or reject an authentication request
      */

--- a/GuardianTests/NotificationSpec.swift
+++ b/GuardianTests/NotificationSpec.swift
@@ -57,6 +57,10 @@ class NotificationSpec: QuickSpec {
                     expect(notification?.transactionToken).to(equal("random_tx_token"))
                 }
 
+                it("should have tx linking id") {
+                    expect(notification?.transactionLinkingId).to(equal("tx_VJGBI87d093cnl03"))
+                }
+
                 it("should have challenge") {
                     expect(notification?.challenge).to(equal("random_challenge"))
                 }
@@ -130,8 +134,13 @@ class NotificationSpec: QuickSpec {
                 }
 
                 it("should fail without tx id") {
-                    notification = AuthenticationNotification(userInfo: payload(token: nil))
+                    notification = AuthenticationNotification(userInfo: payload(transactionToken: nil))
                     expect(notification).to(beNil())
+                }
+
+                it("should not fail without tx linking id") {
+                    notification = AuthenticationNotification(userInfo: payload(transactionLinkingId: nil))
+                    expect(notification).toNot(beNil())
                 }
 
                 it("should fail without challenge") {
@@ -160,7 +169,8 @@ func payload(
              browserVersion: String? = "9.0.3",
              os: String? = "Mac OS",
              osVersion: String? = "10.11.3",
-             token: String? = "random_tx_token",
+             transactionToken: String? = "random_tx_token",
+             transactionLinkingId: String? = "tx_VJGBI87d093cnl03",
              challenge: String? = "random_challenge",
              startedAt: String? = "2015-12-17T19:53:31.000Z",
              host: String? = "samples.auth0.com",
@@ -181,8 +191,11 @@ func payload(
     if device != nil {
         payload["mfa"]!["dai"] = device
     }
-    if token != nil {
-        payload["mfa"]!["txtkn"] = token
+    if transactionToken != nil {
+        payload["mfa"]!["txtkn"] = transactionToken
+    }
+    if transactionLinkingId != nil {
+        payload["mfa"]!["txlnkid"] = transactionLinkingId
     }
     if challenge != nil {
         payload["mfa"]!["c"] = challenge


### PR DESCRIPTION
### Description

To support contextual push notifications, the notification payload will include a new `txlnkid` string property, which stands for “transaction linking id“. 

This PR adds support for this new property, by exposing it in the `Notification` public API through a new `transactionLinkingId` string property. This property is optional because `txlnkid` will not always be present in the notification payload.

### Testing

Unit tests were added.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch