### PR TITLE
feat: Add support for fetching rich consents

### DIFF
--- a/Guardian.xcodeproj/project.pbxproj
+++ b/Guardian.xcodeproj/project.pbxproj
@@ -98,6 +98,9 @@
 		5FAE6729210250E300F149A3 /* AsymmetricPublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAE6728210250E300F149A3 /* AsymmetricPublicKey.swift */; };
 		5FF42BA521091AD10082459F /* NetworkOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF42BA421091AD10082459F /* NetworkOperation.swift */; };
 		5FF42BA821091F150082459F /* NetworkOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF42BA721091F150082459F /* NetworkOperationSpec.swift */; };
+		AB58F6102CF9EE4A00E642F6 /* ConsentAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58F60E2CF9EE4A00E642F6 /* ConsentAPI.swift */; };
+		AB58F6112CF9EE4A00E642F6 /* ConsentAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58F60F2CF9EE4A00E642F6 /* ConsentAPIClient.swift */; };
+		AB9381852D03359700C47B1E /* ConsentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9381842D03359700C47B1E /* ConsentSpec.swift */; };
 		ED1E39A52B7E6C1300E8609A /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E39A42B7E6C1300E8609A /* MockURLProtocol.swift */; };
 		ED1E39A72B822A2500E8609A /* MockURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E39A62B822A2500E8609A /* MockURLResponse.swift */; };
 		ED1E39A92B82A9B100E8609A /* MockURLProtocolCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E39A82B82A9B100E8609A /* MockURLProtocolCondition.swift */; };
@@ -254,6 +257,9 @@
 		5FAE6728210250E300F149A3 /* AsymmetricPublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsymmetricPublicKey.swift; sourceTree = "<group>"; };
 		5FF42BA421091AD10082459F /* NetworkOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkOperation.swift; sourceTree = "<group>"; };
 		5FF42BA721091F150082459F /* NetworkOperationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkOperationSpec.swift; sourceTree = "<group>"; };
+		AB58F60E2CF9EE4A00E642F6 /* ConsentAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAPI.swift; sourceTree = "<group>"; };
+		AB58F60F2CF9EE4A00E642F6 /* ConsentAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAPIClient.swift; sourceTree = "<group>"; };
+		AB9381842D03359700C47B1E /* ConsentSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentSpec.swift; sourceTree = "<group>"; };
 		ED1E39A42B7E6C1300E8609A /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		ED1E39A62B822A2500E8609A /* MockURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLResponse.swift; sourceTree = "<group>"; };
 		ED1E39A82B82A9B100E8609A /* MockURLProtocolCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocolCondition.swift; sourceTree = "<group>"; };
@@ -419,6 +425,8 @@
 			children = (
 				2377A6421D806DFA00D6FB04 /* API.swift */,
 				2374A9E01D670F5900737F2E /* APIClient.swift */,
+				AB58F60E2CF9EE4A00E642F6 /* ConsentAPI.swift */,
+				AB58F60F2CF9EE4A00E642F6 /* ConsentAPIClient.swift */,
 				2377A6401D806D9900D6FB04 /* DeviceAPI.swift */,
 				232A85D91D6BDFCA00048DF7 /* DeviceAPIClient.swift */,
 				5F07A58E210A6E5900819FA2 /* NoContent.swift */,
@@ -500,6 +508,7 @@
 				2356C82F1D88A10600B6C84A /* GuardianSpec.swift */,
 				23D3E43F1D91BEA200F3FDE2 /* Base32Spec.swift */,
 				233F75281D93076600B8C15C /* NotificationSpec.swift */,
+				AB9381842D03359700C47B1E /* ConsentSpec.swift */,
 				5F1DB45C1DA4750F00264437 /* AuthenticationSpec.swift */,
 				2331BFEC1DD52ED50047F1D4 /* JWTSpec.swift */,
 			);
@@ -756,6 +765,8 @@
 				5F07A5AA210FAF9600819FA2 /* JWT.swift in Sources */,
 				5F07A58D210A6DF000819FA2 /* CodableAdditions.swift in Sources */,
 				5F07A58521092C7D00819FA2 /* ClientInfo.swift in Sources */,
+				AB58F6102CF9EE4A00E642F6 /* ConsentAPI.swift in Sources */,
+				AB58F6112CF9EE4A00E642F6 /* ConsentAPIClient.swift in Sources */,
 				5F07A599210F6D1900819FA2 /* Operation.swift in Sources */,
 				5F1604C721063FA000B0F25B /* Keys+Generation.swift in Sources */,
 				2331C01A1DD5FC6F0047F1D4 /* Data+Base64URL.swift in Sources */,
@@ -790,6 +801,7 @@
 				2356C8301D88A10600B6C84A /* GuardianSpec.swift in Sources */,
 				2374A9F51D67339E00737F2E /* Matchers.swift in Sources */,
 				23C67AEC1D81D6A400A38A2E /* MockNSURLSession.swift in Sources */,
+				AB9381852D03359700C47B1E /* ConsentSpec.swift in Sources */,
 				5F1604FB2107AF2800B0F25B /* OneTimePasswordGeneratorSpec.swift in Sources */,
 				ED1E39A92B82A9B100E8609A /* MockURLProtocolCondition.swift in Sources */,
 				5F1604C92106493600B0F25B /* SigningKeyStorageSpec.swift in Sources */,

--- a/Guardian/API/APIClient.swift
+++ b/Guardian/API/APIClient.swift
@@ -77,6 +77,11 @@ struct APIClient: API {
 
 private extension URL {
     func appendingPathComponentIfNeeded(_ pathComponent: String) -> URL {
-        lastPathComponent == pathComponent ? self : appendingPathComponent(pathComponent)
+        guard
+            lastPathComponent != pathComponent,
+            !absoluteString.hasSuffix("guardian.auth0.com"),
+            absoluteString.range(of: "guardian\\.[^\\.]*\\.auth0\\.com", options: .regularExpression) == nil
+        else { return self }
+        return appendingPathComponent(pathComponent)
     }
 }

--- a/Guardian/API/APIClient.swift
+++ b/Guardian/API/APIClient.swift
@@ -23,17 +23,17 @@
 import Foundation
 
 struct APIClient: API {
-
+    private let path = "appliance-mfa"
     let baseUrl: URL
     let telemetryInfo: Auth0TelemetryInfo?
 
     init(baseUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil) {
-        self.baseUrl = baseUrl
+        self.baseUrl = baseUrl.appendingPathComponentIfNeeded(path)
         self.telemetryInfo = telemetryInfo
     }
 
     func enroll(withTicket enrollmentTicket: String, identifier: String, name: String, notificationToken: String, verificationKey: VerificationKey) -> Request<Device, Enrollment> {
-        let url = self.baseUrl.appendingPathComponent("api/enroll")
+        let url = baseUrl.appendingPathComponent("api/enroll")
         do {
             let headers = ["Authorization": "Ticket id=\"\(enrollmentTicket)\""]
             guard let jwk = verificationKey.jwk else {
@@ -50,7 +50,7 @@ struct APIClient: API {
 
     func resolve(transaction transactionToken: String, withChallengeResponse challengeResponse: String) -> Request<Transaction, NoContent> {
         let transaction = Transaction(challengeResponse: challengeResponse)
-        let url = self.baseUrl.appendingPathComponent("api/resolve-transaction")
+        let url = baseUrl.appendingPathComponent("api/resolve-transaction")
         return Request.new(method: .post, url: url, headers: ["Authorization": "Bearer \(transactionToken)"], body: transaction, telemetryInfo: self.telemetryInfo)
     }
 
@@ -64,7 +64,7 @@ struct APIClient: API {
         let claims = BasicClaimSet(
             subject: userId,
             issuer: enrollmentId,
-            audience: self.baseUrl.appendingPathComponent(DeviceAPIClient.path).absoluteString,
+            audience: baseUrl.appendingPathComponent(DeviceAPIClient.path).absoluteString,
             expireAt: currentTime.addingTimeInterval(responseExpiration),
             issuedAt: currentTime
         )
@@ -73,4 +73,10 @@ struct APIClient: API {
         return DeviceAPIClient(baseUrl: baseUrl, id: enrollmentId, token: jwt?.string ?? "", telemetryInfo: self.telemetryInfo)
     }
 
+}
+
+private extension URL {
+    func appendingPathComponentIfNeeded(_ pathComponent: String) -> URL {
+        lastPathComponent == pathComponent ? self : appendingPathComponent(pathComponent)
+    }
 }

--- a/Guardian/API/ConsentAPI.swift
+++ b/Guardian/API/ConsentAPI.swift
@@ -1,0 +1,61 @@
+// ConsentAPI.swift
+//
+// Copyright (c) 2024 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/**
+ `ConsentAPI` lets you retrieve consent objects from auth0's rich-consents API for authentication flows that require additional consent e.g. Client Initiated Backchannel Authentication (CIBA)
+ 
+ ```
+ let device: AuthenticationDevice = // the object you obtained when enrolling
+ let consent = Guardian
+    .consent(forDomain: "tenant.guardian.auth0.com", device: device)
+ ```
+ */
+public protocol ConsentAPI {
+    /**
+     ```
+     let device: AuthenticationDevice = // the object you obtained when enrolling
+     let notification: Notification = // the notification received
+     let consentId = notification.transactionLinkingId
+     
+     Guardian
+        .consent(forDomain: "tenant.guardian.auth0.com", device: device)
+     .get(consentId: consentId, notificationToken: notification.transactionToken)
+     .start { result in
+          switch result {
+          case .success(let payload):
+              // present consent object to user to accept/deny
+          case .failure(let cause):
+              // failed to retrieve consent
+          }
+     }
+     ```
+     
+     - parameter consentId: the id of the consent object to fetch, this is obtained from the
+                            transaction linking id of the ncoming push notification where relevant
+     - parameter transactionToken: the access token obtained from the incoming push notification
+                                    
+     - returns: a request to execute
+     */
+    func get(consentId:String, notificationToken: String) -> Request<NoContent, Consent>
+}

--- a/Guardian/API/ConsentAPI.swift
+++ b/Guardian/API/ConsentAPI.swift
@@ -40,7 +40,7 @@ public protocol ConsentAPI {
      
      Guardian
         .consent(forDomain: "tenant.guardian.auth0.com", device: device)
-     .get(consentId: consentId, notificationToken: notification.transactionToken)
+     .fetch(consentId: consentId, notificationToken: notification.transactionToken)
      .start { result in
           switch result {
           case .success(let payload):
@@ -57,5 +57,5 @@ public protocol ConsentAPI {
                                     
      - returns: a request to execute
      */
-    func get(consentId:String, notificationToken: String) -> Request<NoContent, Consent>
+    func fetch(consentId:String, notificationToken: String) -> Request<NoContent, Consent>
 }

--- a/Guardian/API/ConsentAPI.swift
+++ b/Guardian/API/ConsentAPI.swift
@@ -26,21 +26,19 @@ import Foundation
  `ConsentAPI` lets you retrieve consent objects from auth0's rich-consents API for authentication flows that require additional consent e.g. Client Initiated Backchannel Authentication (CIBA)
  
  ```
- let device: AuthenticationDevice = // the object you obtained when enrolling
  let consent = Guardian
-    .consent(forDomain: "tenant.guardian.auth0.com", device: device)
+    .consent(forDomain: "tenant.region.auth0.com")
  ```
  */
 public protocol ConsentAPI {
     /**
      ```
-     let device: AuthenticationDevice = // the object you obtained when enrolling
      let notification: Notification = // the notification received
      let consentId = notification.transactionLinkingId
      
      Guardian
-        .consent(forDomain: "tenant.guardian.auth0.com", device: device)
-     .fetch(consentId: consentId, notificationToken: notification.transactionToken)
+        .consent(forDomain: "tenant.region.auth0.com")
+     .fetch(consentId: consentId, notificationToken: notification.transactionToken, signingKey: enrollment.signingKey)
      .start { result in
           switch result {
           case .success(let payload):
@@ -54,8 +52,9 @@ public protocol ConsentAPI {
      - parameter consentId: the id of the consent object to fetch, this is obtained from the
                             transaction linking id of the ncoming push notification where relevant
      - parameter transactionToken: the access token obtained from the incoming push notification
+     - parameter signingKey: the private key used to sign Guardian AuthN requests
                                     
      - returns: a request to execute
      */
-    func fetch(consentId:String, notificationToken: String) -> Request<NoContent, Consent>
+    func fetch(consentId: String, transactionToken: String, signingKey: SigningKey) -> Request<NoContent, Consent>
 }

--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -1,0 +1,102 @@
+// ConsentAPIClient.swift
+//
+// Copyright (c) 2024 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import CryptoKit
+
+struct ConsentAPIClient : ConsentAPI {
+    static let path: String = "rich-consents"
+    
+    let url:URL
+    let telemetryInfo: Auth0TelemetryInfo?
+    let privateKey: SecKey
+    let publicKey: VerificationKey
+    
+    init(baseUrl: URL, signingKey:SigningKey, telemetryInfo: Auth0TelemetryInfo? = nil ) {
+        let url = ConsentAPIClient.constructConsentAPIUrl(baseUrl: baseUrl)
+        self.url = url
+        self.telemetryInfo = telemetryInfo
+        self.privateKey = signingKey.secKey
+        self.publicKey = try! signingKey.verificationKey()
+    }
+    
+    func get(consentId:String, notificationToken: String) -> Request<NoContent, Consent> {
+        let consentURL = self.url.appendingPathComponent(consentId)
+        
+        do {
+            let dpopAssertion = try self.proofOfPossesion(url:consentURL, notificationToken:notificationToken)
+            return Request.new(
+                method: .get,
+                url: consentURL,
+                headers: [
+                    "Authorization": "MFA-DPoP \(notificationToken)",
+                    "MFA-DPoP": dpopAssertion
+                ],
+                telemetryInfo: self.telemetryInfo
+            )
+        }
+        catch let error {
+            return Request(method: .get, url: consentURL, error: error)
+        }
+    }
+
+    private static func constructConsentAPIUrl(baseUrl: URL) -> URL {
+        var consentAPIUrl = baseUrl
+        
+        if baseUrl.lastPathComponent == "appliance-mfa" {
+            consentAPIUrl = baseUrl.deletingLastPathComponent()
+        }
+        
+        if baseUrl.host!.components(separatedBy: ".").contains("guardian") {
+            consentAPIUrl = URL(string: baseUrl.absoluteString.replacingOccurrences(of: "guardian.", with: ""))!
+        }
+        
+        return consentAPIUrl.appendingPathComponent(ConsentAPIClient.path, isDirectory: false)
+    }
+    
+    private func proofOfPossesion (url: URL, notificationToken:String) throws -> String {
+        guard let jwk = publicKey.jwk else {
+            throw GuardianError(code: .invalidJWK)
+        }
+        
+        let header = JWT<DPoPClaimSet>.Header(algorithm: .rs256, type: "dpop+jwt", jwk: jwk)
+        let tokenHash = try self.authTokenHash(transactionToken: notificationToken);
+        
+        let claims = DPoPClaimSet(
+            httpURI: url.absoluteString,
+            httpMethod: "GET",
+            accessTokenHash: tokenHash,
+            jti: UUID().uuidString,
+            issuedAt: Date())
+
+         let jwt = try JWT<DPoPClaimSet>(claimSet: claims, header: header, key: self.privateKey)
+         return jwt.string
+    }
+    
+    private func authTokenHash(transactionToken: String) throws -> String {
+        guard let sha256 = A0SHA(algorithm: "sha256") else {
+            throw GuardianError(code: .failedCreationDPoPProof)
+        }
+        
+        return sha256.hash(Data(transactionToken.utf8)).base64URLEncodedString()
+    }
+}

--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -39,7 +39,7 @@ struct ConsentAPIClient : ConsentAPI {
         self.publicKey = try! signingKey.verificationKey()
     }
     
-    func get(consentId:String, notificationToken: String) -> Request<NoContent, Consent> {
+    func fetch(consentId:String, notificationToken: String) -> Request<NoContent, Consent> {
         let consentURL = self.url.appendingPathComponent(consentId)
         
         do {
@@ -66,7 +66,7 @@ struct ConsentAPIClient : ConsentAPI {
             consentAPIUrl = baseUrl.deletingLastPathComponent()
         }
         
-        if baseUrl.host!.components(separatedBy: ".").contains("guardian") {
+        else if baseUrl.host!.components(separatedBy: ".").contains("guardian") {
             consentAPIUrl = URL(string: baseUrl.absoluteString.replacingOccurrences(of: "guardian.", with: ""))!
         }
         

--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -24,31 +24,27 @@ import Foundation
 import CryptoKit
 
 struct ConsentAPIClient : ConsentAPI {
-    static let path: String = "rich-consents"
+    private let path: String = "rich-consents"
     
     let url:URL
     let telemetryInfo: Auth0TelemetryInfo?
-    let privateKey: SecKey
-    let publicKey: VerificationKey
     
-    init(baseUrl: URL, signingKey:SigningKey, telemetryInfo: Auth0TelemetryInfo? = nil ) {
-        let url = ConsentAPIClient.constructConsentAPIUrl(baseUrl: baseUrl)
+    init(baseConsentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil ) {
+        let url = baseConsentUrl.appendingPathComponent(path, isDirectory: false)
         self.url = url
         self.telemetryInfo = telemetryInfo
-        self.privateKey = signingKey.secKey
-        self.publicKey = try! signingKey.verificationKey()
     }
     
-    func fetch(consentId:String, notificationToken: String) -> Request<NoContent, Consent> {
+    func fetch(consentId:String, transactionToken: String, signingKey: SigningKey) -> Request<NoContent, Consent> {
         let consentURL = self.url.appendingPathComponent(consentId)
         
         do {
-            let dpopAssertion = try self.proofOfPossesion(url:consentURL, notificationToken:notificationToken)
+            let dpopAssertion = try self.proofOfPossesion(url: consentURL, transactionToken: transactionToken, signingKey: signingKey)
             return Request.new(
                 method: .get,
                 url: consentURL,
                 headers: [
-                    "Authorization": "MFA-DPoP \(notificationToken)",
+                    "Authorization": "MFA-DPoP \(transactionToken)",
                     "MFA-DPoP": dpopAssertion
                 ],
                 telemetryInfo: self.telemetryInfo
@@ -58,28 +54,14 @@ struct ConsentAPIClient : ConsentAPI {
             return Request(method: .get, url: consentURL, error: error)
         }
     }
-
-    private static func constructConsentAPIUrl(baseUrl: URL) -> URL {
-        var consentAPIUrl = baseUrl
-        
-        if baseUrl.lastPathComponent == "appliance-mfa" {
-            consentAPIUrl = baseUrl.deletingLastPathComponent()
-        }
-        
-        else if baseUrl.host!.components(separatedBy: ".").contains("guardian") {
-            consentAPIUrl = URL(string: baseUrl.absoluteString.replacingOccurrences(of: "guardian.", with: ""))!
-        }
-        
-        return consentAPIUrl.appendingPathComponent(ConsentAPIClient.path, isDirectory: false)
-    }
     
-    private func proofOfPossesion (url: URL, notificationToken:String) throws -> String {
-        guard let jwk = publicKey.jwk else {
+    private func proofOfPossesion (url: URL, transactionToken: String, signingKey: SigningKey) throws -> String {
+        guard let jwk = try signingKey.verificationKey().jwk else {
             throw GuardianError(code: .invalidJWK)
         }
         
         let header = JWT<DPoPClaimSet>.Header(algorithm: .rs256, type: "dpop+jwt", jwk: jwk)
-        let tokenHash = try self.authTokenHash(transactionToken: notificationToken);
+        let tokenHash = try self.authTokenHash(transactionToken: transactionToken);
         
         let claims = DPoPClaimSet(
             httpURI: url.absoluteString,
@@ -88,7 +70,7 @@ struct ConsentAPIClient : ConsentAPI {
             jti: UUID().uuidString,
             issuedAt: Date())
 
-         let jwt = try JWT<DPoPClaimSet>(claimSet: claims, header: header, key: self.privateKey)
+         let jwt = try JWT<DPoPClaimSet>(claimSet: claims, header: header, key: signingKey.secKey)
          return jwt.string
     }
     

--- a/Guardian/API/GuardianError.swift
+++ b/Guardian/API/GuardianError.swift
@@ -47,6 +47,7 @@ public struct GuardianError: Swift.Error {
         case failedStoreAsymmetricKey = "a0.guardian.internal.failed.store_assymmetric_key"
         case notFoundPrivateKey = "a0.guardian.internal.no.private_key"
         case cannotSignTransactionChallenge = "a0.guardian.internal.cannot.sign_challenge"
+        case failedCreationDPoPProof = "a0.guardian.internal.failed.creation_dpop_proof"
     }
 
 }

--- a/Guardian/API/Models.swift
+++ b/Guardian/API/Models.swift
@@ -27,7 +27,7 @@ struct PushCredentials: Codable {
     let token: String
 }
 
-public struct RSAPublicJWK: Codable {
+public struct RSAPublicJWK: Codable, Equatable {
     let keyType = "RSA"
     let usage = "sig"
     let algorithm = "RS256"
@@ -91,6 +91,36 @@ public struct UpdatedDevice: Codable {
         case identifier
         case name
         case pushCredentials = "push_credentials"
+    }
+}
+
+public struct ConsentRequestedDetailsEntity: Decodable {
+    public let audience: String
+    public let scope: [String]
+    public let bindingMessage: String
+    
+    enum CodingKeys: String, CodingKey {
+        case audience
+        case scope
+        case bindingMessage = "binding_message"
+    }
+}
+
+public struct Consent: Decodable {
+    
+    public let consentId: String
+    
+    public let requestedDetails: ConsentRequestedDetailsEntity
+    
+    public let createdAt: String
+    
+    public let expiresAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case consentId = "id"
+        case requestedDetails = "requested_details"
+        case createdAt = "created_at"
+        case expiresAt = "expires_at"
     }
 }
 

--- a/Guardian/Guardian.swift
+++ b/Guardian/Guardian.swift
@@ -384,45 +384,39 @@ public func notification(from userInfo: [AnyHashable: Any]) -> Notification? {
  Creates an consent manager for a Guardian enrollment
 
  ```
- let device: AuthenticationDevice = // the object you obtained when enrolling
  let consent = Guardian
-    .consent(forDomain: "tenant.guardian.auth0.com", device: device)
+    .consent(forDomain: "<tenant>.<region>.auth0.com")
  ```
 
  - parameter forDomain:     domain or URL of your Guardian server
- - parameter device:        the enrolled device that will be used to handle authentication
  - parameter telemetryInfo:       information about the app, used for internal auth0 analitycs purposes
 
  - returns: an `ConsentAPI` instance
  
  - seealso: Guardian.ConsentAPI
  */
-public func consent(forDomain domain: String, device: AuthenticationDevice, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
-    return consent(url: url(from: domain)!, device: device, telemetryInfo: telemetryInfo)
+public func consent(forDomain domain: String, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
+    consent(consentUrl: url(from: domain)!, telemetryInfo: telemetryInfo)
 }
 
 /**
  Creates an consent manager for a Guardian enrollment
 
  ```
- let device: AuthenticationDevice = // the object you obtained when enrolling
  let authenticator = Guardian
-    .consent(url: URL(string: "https://tenant.guardian.auth0.com/")!,
-                    device: device)
+    .consent(url: URL(string: "https://<tenant>.<region>.auth0.com/")!)
  ```
 
  - parameter url:           URL of your Guardian server
- - parameter device:        the enrolled device that will be used to handle authentication
- - parameter telemetryInfo:       information about the app, used for internal auth0 analitycs purposes
+ - parameter telemetryInfo:       information about the app, used for internal auth0 analytics purposes
 
 
  - returns: an `ConsentAPI` instance
 
  - seealso: Guardian.ConsentAPI
  */
-public func consent(url: URL, device: AuthenticationDevice, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
-    let signingKey = device.signingKey;
-    return ConsentAPIClient(baseUrl: url, signingKey:signingKey, telemetryInfo: telemetryInfo)
+public func consent(consentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
+    ConsentAPIClient(baseConsentUrl: consentUrl, telemetryInfo: telemetryInfo)
 }
 
 func url(from domain: String) -> URL? {

--- a/Guardian/Guardian.swift
+++ b/Guardian/Guardian.swift
@@ -380,6 +380,51 @@ public func notification(from userInfo: [AnyHashable: Any]) -> Notification? {
     return AuthenticationNotification(userInfo: userInfo)
 }
 
+/**
+ Creates an consent manager for a Guardian enrollment
+
+ ```
+ let device: AuthenticationDevice = // the object you obtained when enrolling
+ let consent = Guardian
+    .consent(forDomain: "tenant.guardian.auth0.com", device: device)
+ ```
+
+ - parameter forDomain:     domain or URL of your Guardian server
+ - parameter device:        the enrolled device that will be used to handle authentication
+ - parameter telemetryInfo:       information about the app, used for internal auth0 analitycs purposes
+
+ - returns: an `ConsentAPI` instance
+ 
+ - seealso: Guardian.ConsentAPI
+ */
+public func consent(forDomain domain: String, device: AuthenticationDevice, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
+    return consent(url: url(from: domain)!, device: device, telemetryInfo: telemetryInfo)
+}
+
+/**
+ Creates an consent manager for a Guardian enrollment
+
+ ```
+ let device: AuthenticationDevice = // the object you obtained when enrolling
+ let authenticator = Guardian
+    .consent(url: URL(string: "https://tenant.guardian.auth0.com/")!,
+                    device: device)
+ ```
+
+ - parameter url:           URL of your Guardian server
+ - parameter device:        the enrolled device that will be used to handle authentication
+ - parameter telemetryInfo:       information about the app, used for internal auth0 analitycs purposes
+
+
+ - returns: an `ConsentAPI` instance
+
+ - seealso: Guardian.ConsentAPI
+ */
+public func consent(url: URL, device: AuthenticationDevice, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
+    let signingKey = device.signingKey;
+    return ConsentAPIClient(baseUrl: url, signingKey:signingKey, telemetryInfo: telemetryInfo)
+}
+
 func url(from domain: String) -> URL? {
     guard domain.hasPrefix("http") else { return URL(string: "https://\(domain)") }
     return URL(string: domain)

--- a/GuardianApp/AppDelegate.swift
+++ b/GuardianApp/AppDelegate.swift
@@ -27,7 +27,8 @@ import UserNotifications
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    static let guardianDomain = "guardian-demo.guardian.auth0.com"
+    static let tenantDomain = "https://dev-jo51o3afnh6qac8u.us.auth0.com"
+
     static var pushToken: String? = nil
     var window: UIWindow?
 
@@ -126,7 +127,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 completionHandler()
             } else { // Guardian allow/reject action
                 Guardian
-                    .authentication(forDomain: AppDelegate.guardianDomain, device: enrollment)
+                    .authentication(forDomain: AppDelegate.tenantDomain, device: enrollment)
                     .handleAction(withIdentifier: identifier, notification: notification)
                     .start { _ in completionHandler() }
             }

--- a/GuardianApp/Base.lproj/Main.storyboard
+++ b/GuardianApp/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,8 +33,8 @@
                                     <action selector="unenrollAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="X7C-Uh-thk"/>
                                 </connections>
                             </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" distribution="equalSpacing" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="gbr-A3-4Qv">
-                                <rect key="frame" x="16" y="72" width="361" height="90"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="gbr-A3-4Qv">
+                                <rect key="frame" x="16" y="119" width="361" height="90"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENROLLMENT ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XfH-X3-eyB">
                                         <rect key="frame" x="0.0" y="0.0" width="361" height="15.666666666666666"/>
@@ -89,6 +89,7 @@
                             <constraint firstItem="P5n-CT-PTt" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="ql6-df-z0p"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="MFw-sl-2Xh"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="enrollButton" destination="P5n-CT-PTt" id="xQp-B8-5iS"/>
@@ -170,8 +171,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="t7V-Qg-TTK">
-                                <rect key="frame" x="16" y="72" width="361" height="138"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="t7V-Qg-TTK">
+                                <rect key="frame" x="16" y="119" width="361" height="138"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BROWSER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L0h-rj-uGS">
                                         <rect key="frame" x="0.0" y="0.0" width="361" height="15.666666666666666"/>
@@ -205,6 +206,29 @@
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Today at 17:40:10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GSN-Uh-cn2">
                                         <rect key="frame" x="0.0" y="117.66666666666666" width="361" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QZH-1e-kFg">
+                                <rect key="frame" x="16" y="307" width="361" height="51.666666666666686"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you consent to this?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jLf-55-8uK">
+                                        <rect key="frame" x="0.0" y="0.0" width="361" height="15.666666666666666"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Binding Message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zup-wX-DkY">
+                                        <rect key="frame" x="0.0" y="15.666666666666686" width="361" height="15.666666666666664"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ABCD1234" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgY-uW-cgY">
+                                        <rect key="frame" x="0.0" y="31.333333333333314" width="361" height="20.333333333333329"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -245,17 +269,22 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="QZH-1e-kFg" firstAttribute="leading" secondItem="ayv-cV-wfg" secondAttribute="leadingMargin" id="1h7-fY-JRK"/>
+                            <constraint firstItem="ray-6M-hml" firstAttribute="top" secondItem="Ioc-2K-RpH" secondAttribute="bottom" constant="20" id="2qU-b2-quF"/>
                             <constraint firstItem="Ioc-2K-RpH" firstAttribute="leading" secondItem="ayv-cV-wfg" secondAttribute="leadingMargin" id="4ng-0q-Szg"/>
-                            <constraint firstItem="ray-6M-hml" firstAttribute="top" secondItem="Ioc-2K-RpH" secondAttribute="bottom" constant="20" id="9Q8-B5-8rx"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Ioc-2K-RpH" secondAttribute="trailing" id="C3N-HU-oPL"/>
                             <constraint firstItem="t7V-Qg-TTK" firstAttribute="leading" secondItem="ayv-cV-wfg" secondAttribute="leadingMargin" id="Rna-Jd-Vbp"/>
                             <constraint firstItem="t7V-Qg-TTK" firstAttribute="trailing" secondItem="ayv-cV-wfg" secondAttribute="trailingMargin" id="Tlk-Hz-co0"/>
-                            <constraint firstItem="t7V-Qg-TTK" firstAttribute="top" secondItem="cPl-Xp-sKx" secondAttribute="bottom" constant="16" id="VUt-TV-YC7"/>
+                            <constraint firstItem="QZH-1e-kFg" firstAttribute="top" secondItem="t7V-Qg-TTK" secondAttribute="bottom" constant="50" id="UXZ-6F-tDa"/>
+                            <constraint firstItem="t7V-Qg-TTK" firstAttribute="top" secondItem="cPl-Xp-sKx" secondAttribute="bottom" constant="16" id="iSH-2x-I8X"/>
+                            <constraint firstItem="QZH-1e-kFg" firstAttribute="trailing" secondItem="ayv-cV-wfg" secondAttribute="trailingMargin" id="wWJ-hU-c2z"/>
                         </constraints>
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
+                        <outlet property="bindingMessageLabel" destination="xgY-uW-cgY" id="Mfg-31-j7K"/>
                         <outlet property="browserLabel" destination="xc7-mu-JVG" id="NM3-N2-jnz"/>
+                        <outlet property="consentDetailsView" destination="QZH-1e-kFg" id="Bxm-bc-n46"/>
                         <outlet property="dateLabel" destination="GSN-Uh-cn2" id="jhP-xU-RHq"/>
                         <outlet property="locationLabel" destination="RKL-g1-tm5" id="eCd-ib-k97"/>
                     </connections>

--- a/GuardianApp/Base.lproj/Main.storyboard
+++ b/GuardianApp/Base.lproj/Main.storyboard
@@ -76,7 +76,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemGray2Color"/>
                         <constraints>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="d7L-C1-tps" secondAttribute="bottom" constant="20" id="3RK-gf-RFG"/>
                             <constraint firstItem="d7L-C1-tps" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="Bnw-A7-uqh"/>
@@ -267,7 +267,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemGray2Color"/>
                         <constraints>
                             <constraint firstItem="QZH-1e-kFg" firstAttribute="leading" secondItem="ayv-cV-wfg" secondAttribute="leadingMargin" id="1h7-fY-JRK"/>
                             <constraint firstItem="ray-6M-hml" firstAttribute="top" secondItem="Ioc-2K-RpH" secondAttribute="bottom" constant="20" id="2qU-b2-quF"/>
@@ -282,10 +282,12 @@
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
+                        <outlet property="allowButton" destination="pAt-hB-LdP" id="N7c-Jk-akg"/>
                         <outlet property="bindingMessageLabel" destination="xgY-uW-cgY" id="Mfg-31-j7K"/>
                         <outlet property="browserLabel" destination="xc7-mu-JVG" id="NM3-N2-jnz"/>
                         <outlet property="consentDetailsView" destination="QZH-1e-kFg" id="Bxm-bc-n46"/>
                         <outlet property="dateLabel" destination="GSN-Uh-cn2" id="jhP-xU-RHq"/>
+                        <outlet property="denyButton" destination="TSg-91-JQ7" id="6q4-Me-u6H"/>
                         <outlet property="locationLabel" destination="RKL-g1-tm5" id="eCd-ib-k97"/>
                     </connections>
                 </viewController>
@@ -297,6 +299,9 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/GuardianApp/NotificationController.swift
+++ b/GuardianApp/NotificationController.swift
@@ -94,7 +94,7 @@ class NotificationController: UIViewController {
         
         Guardian
             .consent(forDomain: AppDelegate.guardianDomain, device: enrollment)
-            .get(consentId: consentId, notificationToken: notification.transactionToken)
+            .fetch(consentId: consentId, notificationToken: notification.transactionToken)
             .start{ [unowned self] result in
                 switch result {
                 case .failure(let cause):

--- a/GuardianApp/NotificationController.swift
+++ b/GuardianApp/NotificationController.swift
@@ -30,6 +30,9 @@ class NotificationController: UIViewController {
     @IBOutlet var browserLabel: UILabel!
     @IBOutlet var locationLabel: UILabel!
     @IBOutlet var dateLabel: UILabel!
+    
+    @IBOutlet var consentDetailsView: UIStackView!
+    @IBOutlet var bindingMessageLabel: UILabel!
 
     @IBAction func allowAction(_ sender: AnyObject) {
         guard let notification = notification, let enrollment = AppDelegate.state else {
@@ -76,13 +79,38 @@ class NotificationController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        guard let notification = notification, let _ = AppDelegate.state else {
+        guard let notification = notification, let enrollment = AppDelegate.state else {
             return
         }
 
         browserLabel.text = notification.source?.browser?.name ?? "Unknown"
         locationLabel.text = notification.location?.name ?? "Unknown"
         dateLabel.text = "\(notification.startedAt)"
+        self.consentDetailsView.isHidden = true
+        
+        guard let consentId = notification.transactionLinkingId else {
+            return
+        }
+        
+        Guardian
+            .consent(forDomain: AppDelegate.guardianDomain, device: enrollment)
+            .get(consentId: consentId, notificationToken: notification.transactionToken)
+            .start{ [unowned self] result in
+                switch result {
+                case .failure(let cause):
+                    print("Fetch consent failed: \(cause)")
+                case .success(let payload):
+                    updateBindingMessage(bindingMessage: payload.requestedDetails.bindingMessage)
+            }
+        }
+        
+    }
+    
+    func updateBindingMessage(bindingMessage:String) {
+        DispatchQueue.main.async { [unowned self] in
+            self.consentDetailsView.isHidden = false
+            self.bindingMessageLabel.text = bindingMessage
+        }
     }
 
     func showError(_ title: String, _ cause: Swift.Error) {

--- a/GuardianApp/NotificationController.swift
+++ b/GuardianApp/NotificationController.swift
@@ -31,6 +31,9 @@ class NotificationController: UIViewController {
     @IBOutlet var locationLabel: UILabel!
     @IBOutlet var dateLabel: UILabel!
     
+    @IBOutlet var denyButton: UIButton!
+    @IBOutlet var allowButton: UIButton!
+    
     @IBOutlet var consentDetailsView: UIStackView!
     @IBOutlet var bindingMessageLabel: UILabel!
 
@@ -39,7 +42,7 @@ class NotificationController: UIViewController {
             return self.dismiss(animated: true, completion: nil)
         }
         let request = Guardian
-            .authentication(forDomain: AppDelegate.guardianDomain, device: enrollment)
+            .authentication(forDomain: AppDelegate.tenantDomain, device: enrollment)
             .allow(notification: notification)
         debugPrint(request)
         request.start { result in
@@ -60,7 +63,7 @@ class NotificationController: UIViewController {
             return self.dismiss(animated: true, completion: nil)
         }
         let request = Guardian
-            .authentication(forDomain: AppDelegate.guardianDomain, device: enrollment)
+            .authentication(forDomain: AppDelegate.tenantDomain, device: enrollment)
             .reject(notification: notification)
         debugPrint(request)
         request.start { result in
@@ -92,9 +95,12 @@ class NotificationController: UIViewController {
             return
         }
         
+        denyButton.isHidden = true
+        allowButton.isHidden = true
+        
         Guardian
-            .consent(forDomain: AppDelegate.guardianDomain, device: enrollment)
-            .fetch(consentId: consentId, notificationToken: notification.transactionToken)
+            .consent(forDomain: AppDelegate.tenantDomain)
+            .fetch(consentId: consentId, transactionToken: notification.transactionToken, signingKey: enrollment.signingKey)
             .start{ [unowned self] result in
                 switch result {
                 case .failure(let cause):
@@ -103,11 +109,12 @@ class NotificationController: UIViewController {
                     updateBindingMessage(bindingMessage: payload.requestedDetails.bindingMessage)
             }
         }
-        
     }
     
     func updateBindingMessage(bindingMessage:String) {
         DispatchQueue.main.async { [unowned self] in
+            self.denyButton.isHidden = false
+            self.allowButton.isHidden = false
             self.consentDetailsView.isHidden = false
             self.bindingMessageLabel.text = bindingMessage
         }

--- a/GuardianApp/ViewController.swift
+++ b/GuardianApp/ViewController.swift
@@ -43,7 +43,7 @@ class ViewController: UIViewController {
     @IBAction func unenrollAction(_ sender: AnyObject) {
         if let enrollment = AppDelegate.state {
             let request = Guardian
-                .api(forDomain: AppDelegate.guardianDomain)
+                .api(forDomain: AppDelegate.tenantDomain)
                 .device(forEnrollmentId: enrollment.identifier, userId: enrollment.userId, signingKey: enrollment.signingKey)
                 .delete()
             debugPrint(request)
@@ -122,7 +122,7 @@ extension ViewController: QRCodeReaderViewControllerDelegate {
                 let verificationKey = try? signingKey.verificationKey() else { return }
 
             let request = Guardian.enroll(
-                forDomain: AppDelegate.guardianDomain,
+                forDomain: AppDelegate.tenantDomain,
                 usingUri: qrCodeValue,
                 notificationToken: AppDelegate.pushToken!,
                 signingKey: signingKey,

--- a/GuardianTests/APIClientSpec.swift
+++ b/GuardianTests/APIClientSpec.swift
@@ -250,7 +250,7 @@ class APIClientSpec: QuickSpec {
                         isDeleteEnrollment(baseUrl: ValidURL, enrollmentId: ValidEnrollmentId)
                         && hasBearerJWTToken(withSub: ValidUserId,
                                              iss: ValidEnrollmentId,
-                                             aud: ValidURL.appendingPathComponent(DeviceAPIClient.path).absoluteString,
+                                             aud: ValidURL.appendingPathComponent("appliance-mfa").appendingPathComponent(DeviceAPIClient.path).absoluteString,
                                              validFor: ValidBasicJWTDuration),
                     response: { _ in
                         successResponse()
@@ -348,7 +348,7 @@ class APIClientSpec: QuickSpec {
                         isUpdateEnrollment(baseUrl: ValidURL, enrollmentId: ValidEnrollmentId)
                         && hasBearerJWTToken(withSub: ValidUserId,
                                              iss: ValidEnrollmentId,
-                                             aud: ValidURL.appendingPathComponent(DeviceAPIClient.path).absoluteString,
+                                             aud: ValidURL.appendingPathComponent("appliance-mfa").appendingPathComponent(DeviceAPIClient.path).absoluteString,
                                              validFor: ValidBasicJWTDuration),
                     response: { req in
                         let payload = req.a0_payload

--- a/GuardianTests/AuthenticationSpec.swift
+++ b/GuardianTests/AuthenticationSpec.swift
@@ -541,7 +541,7 @@ func checkJWT(request: URLRequest, accepted: Bool, reason: String? = nil, challe
         let jwt: JWT<GuardianClaimSet> = try? JWT(string: challengeResponse),
         let verified = try? jwt.verify(with: verificationKey.secKey),
         verified == true,
-        jwt.claimSet.audience == "https://tenant.guardian.auth0.com/also/works/in/appliance/api/resolve-transaction",
+        jwt.claimSet.audience == "https://tenant.region.auth0.com/appliance-mfa/api/resolve-transaction",
         jwt.claimSet.subject == challenge,
         jwt.claimSet.issuer == EnrolledDevice.vendorIdentifier,
         jwt.claimSet.issuedAt <= currentTime,

--- a/GuardianTests/ConsentSpec.swift
+++ b/GuardianTests/ConsentSpec.swift
@@ -115,6 +115,18 @@ class ConsentSpec: QuickSpec {
                         }
                 }
             }
+            
+            it("should fail when enrollment signing key is not correct") {
+                let anotherDevice = MockAuthenticationDevice(localIdentifier: UUID().uuidString, signingKey: try! DataRSAPrivateKey.new())
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.consent(forDomain: AuthenticationDomain, device: anotherDevice)
+                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .start { result in
+                            expect(result).to(haveGuardianError(withErrorCode: "invalid_dpop_assertion"))
+                            done()
+                        }
+                }
+            }
         }
     }
 }

--- a/GuardianTests/ConsentSpec.swift
+++ b/GuardianTests/ConsentSpec.swift
@@ -1,0 +1,142 @@
+// AuthenticationSpec.swift
+//
+// Copyright (c) 2024 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Quick
+import Nimble
+
+@testable import Guardian
+
+class ConsentSpec: QuickSpec {
+    
+    override class func spec() {
+        
+        var signingKey: SigningKey!
+        var device: MockAuthenticationDevice!
+        
+        beforeEach {
+            MockURLProtocol.startInterceptingRequests()
+            MockURLProtocol.stub(
+                name: "YOU SHALL NOT PASS!",
+                condition: { _ in return true },
+                error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)
+            )
+            signingKey = try! DataRSAPrivateKey.new()
+            device = MockAuthenticationDevice(localIdentifier: UIDevice.current.identifierForVendor!.uuidString, signingKey: signingKey)
+        }
+        
+        afterEach {
+            MockURLProtocol.stopInterceptingRequests()
+        }
+        
+        describe("Consent Url") {
+            beforeEach {
+                MockURLProtocol.stub(
+                    name: "Valid URL",
+                    condition: isGetConsent(baseUrl: ValidAuthenticationURL, consentId: ValidTransactionLinkingId),
+                    response: { req in return consentResponse() }
+                )
+            }
+            
+            it("should succeed when guardian subdomain is passed") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.consent(forDomain: "tenant.guardian.auth0.com", device: device)
+                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .start { result in
+                            expect(result).to(beSuccess())
+                            done()
+                        }
+                }
+            }
+            
+            it("should succeed when canonical domain is passed") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.consent(forDomain: "tenant.auth0.com", device: device)
+                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .start { result in
+                            expect(result).to(beSuccess())
+                            done()
+                        }
+                }
+            }
+            
+            it("should succeed when appliance-mfa domain is passed") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.consent(forDomain: "tenant.auth0.com/appliance-mfa", device: device)
+                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .start { result in
+                            expect(result).to(beSuccess())
+                            done()
+                        }
+                }
+            }
+        }
+        
+        describe("DPoP validation") {
+            beforeEach {
+                MockURLProtocol.stub(
+                    name: "Checking DPoP",
+                    condition: isGetConsent(baseUrl: ValidAuthenticationURL, consentId: ValidTransactionLinkingId) && hasDPoPToken(ValidTransactionToken),
+                    response: { req in
+                        if checkDPoPAssertion(request: req, verificationKey: device.verificationKey) {
+                            return consentResponse()
+                        }
+                        
+                        return errorResponse(statusCode: 403, errorCode: "invalid_dpop_assertion", message: "Invalid DPoP Assertion")
+                    }
+                )
+            }
+            
+            it("should succeed when notification and enrollment is valid") {
+                waitUntil(timeout: Timeout) { done in
+                    Guardian.consent(forDomain: AuthenticationDomain, device: device)
+                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .start { result in
+                            expect(result).to(beSuccess())
+                            done()
+                        }
+                }
+            }
+        }
+    }
+}
+
+
+func checkDPoPAssertion(request: URLRequest, verificationKey: AsymmetricPublicKey) -> Bool {
+    let currentTime = Date()
+    if let assertion = request.value(forHTTPHeaderField: "MFA-DPoP"),
+       let jwt = try? JWT<DPoPClaimSet>(string: assertion),
+       let verified = try? jwt.verify(with: verificationKey.secKey),
+       verified,
+       jwt.claimSet.httpMethod == "GET",
+       jwt.claimSet.issuedAt <= currentTime,
+       jwt.claimSet.issuedAt >= currentTime.addingTimeInterval(-5),
+       !jwt.claimSet.jti.isEmpty,
+       jwt.claimSet.accessTokenHash == ValidTransactionTokenShah256,
+       jwt.header.algorithm == .rs256,
+       jwt.header.type == "dpop+jwt",
+       jwt.header.jwk == verificationKey.jwk
+    {
+      return true
+    }
+    
+    return false
+}

--- a/GuardianTests/ConsentSpec.swift
+++ b/GuardianTests/ConsentSpec.swift
@@ -56,32 +56,10 @@ class ConsentSpec: QuickSpec {
                 )
             }
             
-            it("should succeed when guardian subdomain is passed") {
-                waitUntil(timeout: Timeout) { done in
-                    Guardian.consent(forDomain: "tenant.guardian.auth0.com", device: device)
-                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
-                        .start { result in
-                            expect(result).to(beSuccess())
-                            done()
-                        }
-                }
-            }
-            
             it("should succeed when canonical domain is passed") {
                 waitUntil(timeout: Timeout) { done in
-                    Guardian.consent(forDomain: "tenant.auth0.com", device: device)
-                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
-                        .start { result in
-                            expect(result).to(beSuccess())
-                            done()
-                        }
-                }
-            }
-            
-            it("should succeed when appliance-mfa domain is passed") {
-                waitUntil(timeout: Timeout) { done in
-                    Guardian.consent(forDomain: "tenant.auth0.com/appliance-mfa", device: device)
-                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                    Guardian.consent(forDomain: "tenant.auth0.com")
+                        .fetch(consentId: ValidTransactionLinkingId, transactionToken: ValidTransactionToken, signingKey: signingKey)
                         .start { result in
                             expect(result).to(beSuccess())
                             done()
@@ -107,8 +85,8 @@ class ConsentSpec: QuickSpec {
             
             it("should succeed when notification and enrollment is valid") {
                 waitUntil(timeout: Timeout) { done in
-                    Guardian.consent(forDomain: AuthenticationDomain, device: device)
-                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                    Guardian.consent(forDomain: AuthenticationDomain)
+                        .fetch(consentId: ValidTransactionLinkingId, transactionToken: ValidTransactionToken, signingKey: signingKey)
                         .start { result in
                             expect(result).to(beSuccess())
                             done()
@@ -117,10 +95,9 @@ class ConsentSpec: QuickSpec {
             }
             
             it("should fail when enrollment signing key is not correct") {
-                let anotherDevice = MockAuthenticationDevice(localIdentifier: UUID().uuidString, signingKey: try! DataRSAPrivateKey.new())
                 waitUntil(timeout: Timeout) { done in
-                    Guardian.consent(forDomain: AuthenticationDomain, device: anotherDevice)
-                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                    Guardian.consent(forDomain: AuthenticationDomain)
+                        .fetch(consentId: ValidTransactionLinkingId, transactionToken: ValidTransactionToken, signingKey: try! DataRSAPrivateKey.new())
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: "invalid_dpop_assertion"))
                             done()

--- a/GuardianTests/ConsentSpec.swift
+++ b/GuardianTests/ConsentSpec.swift
@@ -59,7 +59,7 @@ class ConsentSpec: QuickSpec {
             it("should succeed when guardian subdomain is passed") {
                 waitUntil(timeout: Timeout) { done in
                     Guardian.consent(forDomain: "tenant.guardian.auth0.com", device: device)
-                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
                         .start { result in
                             expect(result).to(beSuccess())
                             done()
@@ -70,7 +70,7 @@ class ConsentSpec: QuickSpec {
             it("should succeed when canonical domain is passed") {
                 waitUntil(timeout: Timeout) { done in
                     Guardian.consent(forDomain: "tenant.auth0.com", device: device)
-                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
                         .start { result in
                             expect(result).to(beSuccess())
                             done()
@@ -81,7 +81,7 @@ class ConsentSpec: QuickSpec {
             it("should succeed when appliance-mfa domain is passed") {
                 waitUntil(timeout: Timeout) { done in
                     Guardian.consent(forDomain: "tenant.auth0.com/appliance-mfa", device: device)
-                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
                         .start { result in
                             expect(result).to(beSuccess())
                             done()
@@ -108,7 +108,7 @@ class ConsentSpec: QuickSpec {
             it("should succeed when notification and enrollment is valid") {
                 waitUntil(timeout: Timeout) { done in
                     Guardian.consent(forDomain: AuthenticationDomain, device: device)
-                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
                         .start { result in
                             expect(result).to(beSuccess())
                             done()
@@ -120,7 +120,7 @@ class ConsentSpec: QuickSpec {
                 let anotherDevice = MockAuthenticationDevice(localIdentifier: UUID().uuidString, signingKey: try! DataRSAPrivateKey.new())
                 waitUntil(timeout: Timeout) { done in
                     Guardian.consent(forDomain: AuthenticationDomain, device: anotherDevice)
-                        .get(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
+                        .fetch(consentId: ValidTransactionLinkingId, notificationToken: ValidTransactionToken)
                         .start { result in
                             expect(result).to(haveGuardianError(withErrorCode: "invalid_dpop_assertion"))
                             done()

--- a/GuardianTests/Constants.swift
+++ b/GuardianTests/Constants.swift
@@ -25,7 +25,7 @@ import Nimble
 
 @testable import Guardian
 
-let Domain = "tenant.guardian.auth0.com/also/works/in/appliance/"
+let Domain = "tenant.region.auth0.com"
 let Timeout: NimbleTimeInterval = .seconds(2)
 
 let ValidURL = URL(string: "https://\(Domain)")!

--- a/GuardianTests/Constants.swift
+++ b/GuardianTests/Constants.swift
@@ -42,6 +42,7 @@ let ValidAlgorithm = HMACAlgorithm.sha1
 let ValidDigits = 7
 let ValidPeriod = 29
 let ValidTransactionToken = "aValidTransactionToken"
+let ValidTransactionTokenShah256 = "CzMD9-OOC7tzMpYDBdgrSUtmhx8Jw9cZMSf4KXVRC5A"
 let RejectReason = "aRejectReason"
 let ValidChallengeResponse = "aValidChallengeResponse"
 let ValidBasicJWTDuration: TimeInterval = 60 * 60 * 2
@@ -50,3 +51,8 @@ let ValidDeviceName = "aValidDeviceName"
 let ValidNotificationService = "APNS"
 let DeviceAccountToken = UUID().uuidString
 let ValidNotificationChallenge = "aValidNotificationChallenge"
+let ValidTransactionLinkingId = "cns_1234"
+
+
+let AuthenticationDomain = "tenant.auth0.com"
+let ValidAuthenticationURL = URL(string: "https://\(AuthenticationDomain)")!

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -54,9 +54,17 @@ class GuardianSpec: QuickSpec {
         }
 
         describe("api(url:)") {
-
+            
             it("should return api with url only") {
                 expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!)).toNot(beNil())
+            }
+            
+            it("should have base url with single 'appliance-mfa' component for passed url without this component") {
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!).baseUrl.absoluteString).to(equal("https://samples.guardian.auth0.com/appliance-mfa"))
+            }
+            
+            it("should have base url with single 'appliance-mfa' component for passed url with this component") {
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com/appliance-mfa")!).baseUrl.absoluteString).to(equal("https://samples.guardian.auth0.com/appliance-mfa"))
             }
         }
 
@@ -354,23 +362,19 @@ class GuardianSpec: QuickSpec {
             }
         }
         
-        describe("consent(forDomain:, device:)") {
-            let device = EnrolledDevice(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: try! DataRSAPrivateKey.new())
-            
+        describe("consent(forDomain:)") {
             it("should return consent api with domain only") {
-                expect(Guardian.consent(forDomain: "samples.guardian.auth0.com", device: device)).toNot(beNil())
+                expect(Guardian.consent(forDomain: "samples.guardian.auth0.com")).toNot(beNil())
             }
             
             it("should return consent api with http url") {
-                expect(Guardian.consent(forDomain: "https://samples.guardian.auth0.com", device: device)).toNot(beNil())
+                expect(Guardian.consent(forDomain: "https://samples.guardian.auth0.com")).toNot(beNil())
             }
         }
 
-        describe("consent(url:, device:)") {
-            let device = EnrolledDevice(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: try! DataRSAPrivateKey.new())
-
+        describe("consent(url:)") {
             it("should return authentication with http url") {
-                expect(Guardian.consent(url: URL(string: "https://samples.guardian.auth0.com")!, device: device)).toNot(beNil())
+                expect(Guardian.consent(consentUrl: URL(string: "https://samples.guardian.auth0.com")!)).toNot(beNil())
             }
         }
     }

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -353,6 +353,26 @@ class GuardianSpec: QuickSpec {
                 }
             }
         }
+        
+        describe("consent(forDomain:, device:)") {
+            let device = EnrolledDevice(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: try! DataRSAPrivateKey.new())
+            
+            it("should return consent api with domain only") {
+                expect(Guardian.consent(forDomain: "samples.guardian.auth0.com", device: device)).toNot(beNil())
+            }
+            
+            it("should return consent api with http url") {
+                expect(Guardian.consent(forDomain: "https://samples.guardian.auth0.com", device: device)).toNot(beNil())
+            }
+        }
+
+        describe("consent(url:, device:)") {
+            let device = EnrolledDevice(id: "ID", userId: "USER_ID", deviceToken: "TOKEN", notificationToken: "TOKEN", signingKey: try! DataRSAPrivateKey.new())
+
+            it("should return authentication with http url") {
+                expect(Guardian.consent(url: URL(string: "https://samples.guardian.auth0.com")!, device: device)).toNot(beNil())
+            }
+        }
     }
 }
 

--- a/GuardianTests/GuardianSpec.swift
+++ b/GuardianTests/GuardianSpec.swift
@@ -58,13 +58,27 @@ class GuardianSpec: QuickSpec {
             it("should return api with url only") {
                 expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!)).toNot(beNil())
             }
-            
-            it("should have base url with single 'appliance-mfa' component for passed url without this component") {
-                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!).baseUrl.absoluteString).to(equal("https://samples.guardian.auth0.com/appliance-mfa"))
+        }
+        
+        describe("adding path component") {
+            it("should not add path component to url with guardian.auth0.com suffix") {
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com")!).baseUrl.absoluteString).to(equal("https://samples.guardian.auth0.com"))
             }
             
-            it("should have base url with single 'appliance-mfa' component for passed url with this component") {
-                expect(Guardian.api(url: URL(string: "https://samples.guardian.auth0.com/appliance-mfa")!).baseUrl.absoluteString).to(equal("https://samples.guardian.auth0.com/appliance-mfa"))
+            it("should not add path component to url with guardian.region.auth0.com") {
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.en.auth0.com")!).baseUrl.absoluteString).to(equal("https://samples.guardian.en.auth0.com"))
+            }
+            
+            it("should not add path component to custom url without guardian with already added path component") {
+                expect(Guardian.api(url: URL(string: "https://samples.auth0.com/appliance-mfa")!).baseUrl.absoluteString).to(equal("https://samples.auth0.com/appliance-mfa"))
+            }
+            
+            it("should add path component to custom url without guardian without already added path component") {
+                expect(Guardian.api(url: URL(string: "https://samples.auth0.com")!).baseUrl.absoluteString).to(equal("https://samples.auth0.com/appliance-mfa"))
+            }
+            
+            it("should add path component to custom url with guardian without already added path component") {
+                expect(Guardian.api(url: URL(string: "https://samples.guardian.some.thing.auth0.com")!).baseUrl.absoluteString).to(equal("https://samples.guardian.some.thing.auth0.com/appliance-mfa"))
             }
         }
 

--- a/GuardianTests/JWTSpec.swift
+++ b/GuardianTests/JWTSpec.swift
@@ -39,7 +39,6 @@ class JWTSpec: QuickSpec {
 
         describe("signature") {
 
-            var jwt: JWT<TestClaimSet>?
 
             describe("RS256") {
 
@@ -49,9 +48,7 @@ class JWTSpec: QuickSpec {
                     let verificationKey = try! AsymmetricPublicKey(privateKey: signingKey.secKey)
                     let anotherVerificationKey = try! AsymmetricPublicKey(privateKey: DataRSAPrivateKey.new().secKey)
 
-                    beforeEach {
-                        jwt = try? JWT(claimSet: TestClaimSet(field: "value"), key: signingKey.secKey)
-                    }
+                    let jwt = try? JWT(claimSet: TestClaimSet(field: "value"), key: signingKey.secKey)
 
                     it("should match hardcoded jwt") {
                         expect(jwt?.string).to(equal(aToken))

--- a/GuardianTests/JWTSpec.swift
+++ b/GuardianTests/JWTSpec.swift
@@ -219,6 +219,97 @@ class JWTSpec: QuickSpec {
                 }
             }
         }
+        
+        describe("header") {
+            describe("init(algorithm:)") {
+                let header = JWT<TestClaimSet>.Header(algorithm: .rs256);
+                
+                it("should create instance") {
+                    expect(header).toNot(beNil())
+                }
+                
+                it("should set correct algorithm") {
+                    expect(header.algorithm).to(equal(.rs256))
+                }
+                
+                it("should default type to JWT") {
+                    expect(header.type).to(equal("JWT"))
+                }
+                
+                it("should not set jwk by default") {
+                    expect(header.jwk).to(beNil())
+                }
+            }
+            
+            describe("init(algorithm: type: jwk:)") {
+                let key = RSAPublicJWK(modulus: "1", exponent: "2")
+                let header = JWT<TestClaimSet>.Header(algorithm: .rs256, type: "dpop+jwt", jwk: key);
+                
+                it("should create instance") {
+                    expect(header).toNot(beNil())
+                }
+                
+                it("should set correct algorithm") {
+                    expect(header.algorithm).to(equal(.rs256))
+                }
+                
+                it("should default type to JWT") {
+                    expect(header.type).to(equal("dpop+jwt"))
+                }
+                
+                it("should not set jwk by default") {
+                    expect(header.jwk).to(equal(key))
+                }
+            }
+            
+            describe("encode") {
+                describe("without jwks") {
+                    let header = JWT<TestClaimSet>.Header(algorithm: .rs256)
+                    let encoder = JSONEncoder()
+                    let jsonString = String(data: try! encoder.encode(header), encoding: .utf8)
+                    
+                    it("should only encode the that are set") {
+                        expect(jsonString).to(contain(#""alg":"RS256""#))
+                        expect(jsonString).to(contain(#""typ":"JWT""#))
+                    }
+                }
+                
+                describe("with jwks") {
+                    let key = RSAPublicJWK(modulus: "1", exponent: "2")
+                    let header = JWT<TestClaimSet>.Header(algorithm: .rs256, type: "dpop+jwt", jwk: key);
+                    let encoder = JSONEncoder()
+                    let jsonString = String(data: try! encoder.encode(header), encoding: .utf8)
+                    
+                    it("should encode the all keys") {
+                        expect(jsonString).to(contain(#""alg":"RS256""#))
+                        expect(jsonString).to(contain(#""typ":"dpop+jwt""#))
+                        expect(jsonString).to(contain(#""jwk":"#))
+                    }
+                }
+            }
+            
+            describe("DPoP claims") {
+                let claims = DPoPClaimSet(
+                        httpURI: "auth0.com",
+                        httpMethod: "GET",
+                        accessTokenHash: "1234",
+                        jti: "nonce",
+                        issuedAt: Date.init(timeIntervalSince1970: 0)
+                    )
+
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .secondsSince1970
+                let jsonString = String(data: try! encoder.encode(claims), encoding: .utf8)
+                
+                it("should encode the all keys") {
+                    expect(jsonString).to(contain(#""htu":"auth0.com""#))
+                    expect(jsonString).to(contain(#""htm":"GET""#))
+                    expect(jsonString).to(contain(#""ath":"1234""#))
+                    expect(jsonString).to(contain(#""jti":"nonce"#))
+                    expect(jsonString).to(contain(#""iat":0"#))
+                }
+            }
+        }
     }
 }
 

--- a/GuardianTests/Matchers.swift
+++ b/GuardianTests/Matchers.swift
@@ -29,6 +29,10 @@ func isMobileEnroll(baseUrl: URL) -> MockURLProtocolCondition {
     return isScheme("https") && isMethodPOST() && isUrl(from: baseUrl, endingWithPathComponent: "api/enroll")
 }
 
+func isMethodGET() -> MockURLProtocolCondition {
+  return { $0.httpMethod == "GET" }
+}
+
 func isMethodPOST() -> MockURLProtocolCondition {
   return { $0.httpMethod == "POST" }
 }
@@ -101,6 +105,18 @@ func hasBearerToken(_ token: String) -> MockURLProtocolCondition {
     }
 }
 
+func hasDPoPToken(_ token: String) -> MockURLProtocolCondition {
+    return { request in
+        return request.value(forHTTPHeaderField: "Authorization") == "MFA-DPoP \(token)"
+    }
+}
+
+func hasDPoPAssertion(_ assertion: String) -> MockURLProtocolCondition {
+    return { request in
+        return request.value(forHTTPHeaderField: "MFA-DPoP") == assertion
+    }
+}
+
 func isDeleteEnrollment(baseUrl: URL, enrollmentId: String? = nil) -> MockURLProtocolCondition {
     return isMethodDELETE() && isEnrollment(baseUrl: baseUrl, enrollmentId: enrollmentId)
 }
@@ -134,6 +150,11 @@ func hasBearerJWTToken(withSub sub: String, iss: String, aud: String, validFor d
 
 func isUpdateEnrollment(baseUrl: URL, enrollmentId: String? = nil) -> MockURLProtocolCondition {
     return isMethodPATCH() && isEnrollment(baseUrl: baseUrl, enrollmentId: enrollmentId)
+}
+
+
+func isGetConsent(baseUrl: URL, consentId: String) -> MockURLProtocolCondition {
+    return isScheme("https") && isMethodGET() && isUrl(from: baseUrl, endingWithPathComponent: "rich-consents/\(consentId)")
 }
 
 func beUpdatedDevice(deviceIdentifier: String?, deviceName: String?, notificationService: String?, notificationToken: String?) -> Nimble.Predicate<Result<UpdatedDevice>> {

--- a/GuardianTests/Matchers.swift
+++ b/GuardianTests/Matchers.swift
@@ -26,7 +26,7 @@ import Nimble
 @testable import Guardian
 
 func isMobileEnroll(baseUrl: URL) -> MockURLProtocolCondition {
-    return isScheme("https") && isMethodPOST() && isUrl(from: baseUrl, endingWithPathComponent: "api/enroll")
+    return isScheme("https") && isMethodPOST() && isUrl(from: baseUrl, endingWithPathComponent: "appliance-mfa/api/enroll")
 }
 
 func isMethodGET() -> MockURLProtocolCondition {
@@ -61,8 +61,9 @@ func isUrl(from baseUrl: URL, containingPathStartingWith path: String) -> MockUR
 }
 
 func isUrl(from baseUrl: URL, endingWithPathComponent pathComponent: String) -> MockURLProtocolCondition {
-    return { req in
-        return req.url == baseUrl.appendingPathComponent(pathComponent)
+    { req in
+        guard let url = req.url else { return false }
+        return url.absoluteString.hasSuffix(pathComponent)
     }
 }
 
@@ -96,7 +97,7 @@ func hasField(_ field: String, withParameters parameters: [String: String]) -> M
 }
 
 func isResolveTransaction(baseUrl: URL) -> MockURLProtocolCondition {
-    return isScheme("https") && isMethodPOST() && isUrl(from: baseUrl, endingWithPathComponent: "api/resolve-transaction")
+    return isScheme("https") && isMethodPOST() && isUrl(from: baseUrl, endingWithPathComponent: "appliance-mfa/api/resolve-transaction")
 }
 
 func hasBearerToken(_ token: String) -> MockURLProtocolCondition {
@@ -123,9 +124,9 @@ func isDeleteEnrollment(baseUrl: URL, enrollmentId: String? = nil) -> MockURLPro
 
 func isEnrollment(baseUrl: URL, enrollmentId: String? = nil) -> MockURLProtocolCondition {
     if let enrollmentId = enrollmentId {
-        return isUrl(from: baseUrl, endingWithPathComponent: "api/device-accounts/\(enrollmentId)")
+        return isUrl(from: baseUrl, endingWithPathComponent: "appliance-mfa/api/device-accounts/\(enrollmentId)")
     }
-    return isUrl(from: baseUrl, containingPathStartingWith: "api/device-accounts/")
+    return isUrl(from: baseUrl, containingPathStartingWith: "appliance-mfa/api/device-accounts/")
 }
 
 func hasBearerJWTToken(withSub sub: String, iss: String, aud: String, validFor duration: TimeInterval) -> MockURLProtocolCondition {

--- a/GuardianTests/Responses.swift
+++ b/GuardianTests/Responses.swift
@@ -66,6 +66,21 @@ func deviceResponse(enrollmentId id: String?, deviceIdentifier: String?, name: S
     return MockURLResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
+func consentResponse() -> MockURLResponse {
+    let json: [String : Any] = [
+        "id": "",
+        "created_at": "",
+        "expires_at": "",
+        "requested_details": [
+            "audience": "",
+            "scope": [],
+            "binding_message": ""
+        ]
+    ]
+    
+    return MockURLResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+}
+
 func successResponse(statusCode: Int = 200) -> MockURLResponse {
     return MockURLResponse(jsonObject: [:], statusCode: statusCode, headers: ["Content-Type": "application/json"])
 }

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ github "auth0/Guardian.swift" ~> 1.4.2
 import Guardian
 ```
 
-Set the auth0 domain for your tenant:
+Set the auth0 domains for your tenant:
 ```swift
-let domain = "https://<tenant>.<locality>.auth0.com/appliance-mfa"
+let tenantDomain      = "<tenant>.<region>.auth0.com"
 ```
 
-alternatively you can use the custom domain if you configured one:
+alternatively you can use a custom domain if you configured one in your auth0 tenant:
 ```swift
-let domain = "https://<custom>/appliance-mfa"
+let tenantDomain      = "<custom>"
 ```
 
 ### Enroll
@@ -82,7 +82,7 @@ after your have all of them, you can enroll your device
 
 ```swift
 Guardian
-        .enroll(forDomain: "{YOUR_GUARDIAN_DOMAIN}",
+        .enroll(forDomain: tenantDomain,
                 usingUri: "{ENROLLMENT_URI}",
                 notificationToken: "{APNS_TOKEN}",
                 signingKey: signingKey,
@@ -170,7 +170,7 @@ Then just call
 
 ```swift
 Guardian
-        .authentication(forDomain: "{YOUR_GUARDIAN_DOMAIN}", device: device)
+        .authentication(forDomain: tenantDomain, device: device)
         .allow(notification: notification)
         .start { result in
             switch result {
@@ -189,7 +189,7 @@ you want. The reject reason will be available in the guardian logs.
 
 ```swift
 Guardian
-        .authentication(forDomain: "{YOUR_GUARDIAN_DOMAIN}", device: device)
+        .authentication(forDomain: tenantDomain, device: device)
         .reject(notification: notification)
         // or reject(notification: notification, withReason: "hacked")
         .start { result in
@@ -205,25 +205,24 @@ Guardian
 ### Fetch rich consent details
 
 When you receive a push notification, the presence of the property `tranactionLinkingId` indicates a
-rich consent record may be associated to the tranaction.
+rich consent record may be associated to the transaction.
 
 To fetch the rich consent details, you can use the `consent.fetch` method.
 
 ```swift
 if let consentId = notification.transactionLinkingId {
     Guardian
-        .consent(forDomain: AppDelegate.guardianDomain, device: enrollment)
-        .fetch(consentId: consentId, notificationToken: notification.transactionToken)
-        .start{ [unowned self] result in
+        .consent(forDomain: tenantDomain)
+        .fetch(consentId: consentId, notificationToken: notification.transactionToken, signingKey: enrollment.signingKey)
+        .start { [unowned self] result in
             switch result {
-            case .success(let payload):
-                // present consent details to the user
             case .failure(let cause):
                 // something failed, check cause to see what went wrong
+            case .success(let payload):
+                // present consent details to the user
+            }
         }
-    }
 }
-
 ```
 
 ### Unenroll
@@ -233,7 +232,7 @@ following request:
 
 ```swift
 Guardian
-        .api(forDomain: "{YOUR_GUARDIAN_DOMAIN}")
+        .api(forDomain: tenantDomain)
         .device(forEnrollmentId: "{USER_ENROLLMENT_ID}", token: "{ENROLLMENT_DEVICE_TOKEN}")
         .delete()
         .start { result in

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ github "auth0/Guardian.swift" ~> 1.4.2
 import Guardian
 ```
 
-Set the auth0 domains for your tenant:
+Set the domain for your auth0 tenant:
 ```swift
 let tenantDomain      = "<tenant>.<region>.auth0.com"
 ```

--- a/README.md
+++ b/README.md
@@ -202,6 +202,30 @@ Guardian
         }
 ```
 
+### Fetch rich consent details
+
+When you receive a push notification, the presence of the property `tranactionLinkingId` indicates a
+rich consent record may be associated to the tranaction.
+
+To fetch the rich consent details, you can use the `consent.fetch` method.
+
+```swift
+if let consentId = notification.transactionLinkingId {
+    Guardian
+        .consent(forDomain: AppDelegate.guardianDomain, device: enrollment)
+        .fetch(consentId: consentId, notificationToken: notification.transactionToken)
+        .start{ [unowned self] result in
+            switch result {
+            case .success(let payload):
+                // present consent details to the user
+            case .failure(let cause):
+                // something failed, check cause to see what went wrong
+        }
+    }
+}
+
+```
+
 ### Unenroll
 
 If you want to delete an enrollment -for example if you want to disable MFA- you can make the


### PR DESCRIPTION
### Description

Adds the ability to retrieve  additional consent information from Auth0's `/rich-consents` endpoint. This is required for certain flows such Client Initiated Backchannel Authentication (CIBA).

On receipt of a push notification, where required, additional consent can be obtained as follows:

```
Guardian
    .consent(forDomain: AppDelegate.guardianDomain, device: enrollment)
    .fetch(consentId: notification.transactionLinkingId, notificationToken: notification.transactionToken)
    .start{result in
        switch result {
        case .failure(let cause):
            // handle error
        case .success(let payload):
            // render consent information to user
    }
}
```
The user can then use the additional information in the consent record to decide whether to allow or reject the request.

Example of rich-consents binding message being rendered in the test app:

<img src="https://github.com/user-attachments/assets/a283f134-22d6-4afe-921b-d05ab1f70ced" width="300">

Requests to the `/rich-consent` endpoint require sender constraining via demonstrating proof of possession based on a modified version of the DPoP standard to ensure the access token is bound to the keys used for device enrollment. This change also extends the existing JWT encoding to be able to create a [DPoP Proof JWT](https://datatracker.ietf.org/doc/html/rfc9449#name-dpop-proof-jwt-syntax).

### References
- [OIDC CIBA Spec](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)
- [DPoP Spec](https://datatracker.ietf.org/doc/html/rfc9449)
### Testing

1. Requires CIBA flow enabled for you Auth0 tenant (currently in Beta).
2. Enable CIBA grant on your Auth0 application under [application settings](https://auth0.com/docs/get-started/applications/application-settings#grant-types).
3. Using the TestApp included in this repo, [configure Guardian MFA for iOS using APNs](https://auth0.com/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-push-notifications-for-mfa#configure-push-notifications-for-ios-using-apns)
4. Enroll the device for a user
5. Initiate a [CIBA auth request](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request)
6. Device should receive a push notification, rendering a consent panel with the CIBA binding message.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
