### PR TITLE
[FGI-1206] Modify Guardian.iOS SDK to handle being passed a url with a .guardian. subdomain

### DIFF
--- a/Guardian.xcodeproj/project.pbxproj
+++ b/Guardian.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		AB9381852D03359700C47B1E /* ConsentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9381842D03359700C47B1E /* ConsentSpec.swift */; };
 		AB96591D2D64E27600FB23F3 /* ModelsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB96591C2D64E27600FB23F3 /* ModelsSpec.swift */; };
 		AB9659212D6620BA00FB23F3 /* Json.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9659202D6620B300FB23F3 /* Json.swift */; };
+		ED0102702E313A9D00BA19E7 /* ConsentApiClientSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED01026F2E313A9B00BA19E7 /* ConsentApiClientSpec.swift */; };
 		ED1E39A52B7E6C1300E8609A /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E39A42B7E6C1300E8609A /* MockURLProtocol.swift */; };
 		ED1E39A72B822A2500E8609A /* MockURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E39A62B822A2500E8609A /* MockURLResponse.swift */; };
 		ED1E39A92B82A9B100E8609A /* MockURLProtocolCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E39A82B82A9B100E8609A /* MockURLProtocolCondition.swift */; };
@@ -255,6 +256,7 @@
 		AB9381842D03359700C47B1E /* ConsentSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentSpec.swift; sourceTree = "<group>"; };
 		AB96591C2D64E27600FB23F3 /* ModelsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsSpec.swift; sourceTree = "<group>"; };
 		AB9659202D6620B300FB23F3 /* Json.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Json.swift; sourceTree = "<group>"; };
+		ED01026F2E313A9B00BA19E7 /* ConsentApiClientSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentApiClientSpec.swift; sourceTree = "<group>"; };
 		ED1E39A42B7E6C1300E8609A /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		ED1E39A62B822A2500E8609A /* MockURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLResponse.swift; sourceTree = "<group>"; };
 		ED1E39A82B82A9B100E8609A /* MockURLProtocolCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocolCondition.swift; sourceTree = "<group>"; };
@@ -327,6 +329,7 @@
 		5F07A5A1210F9A0700819FA2 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				ED01026F2E313A9B00BA19E7 /* ConsentApiClientSpec.swift */,
 				5F07A5A2210F9A1200819FA2 /* NoContentSpec.swift */,
 				AB96591C2D64E27600FB23F3 /* ModelsSpec.swift */,
 				5F07A5A7210FA08B00819FA2 /* RequestSpec.swift */,
@@ -815,6 +818,7 @@
 				5F1604C92106493600B0F25B /* SigningKeyStorageSpec.swift in Sources */,
 				5F7969341DDABDDE006AC7BA /* AuthenticationSpec.swift in Sources */,
 				5F07A5AC210FD09F00819FA2 /* GuardianErrorSpec.swift in Sources */,
+				ED0102702E313A9D00BA19E7 /* ConsentApiClientSpec.swift in Sources */,
 				2374A9F31D672E4F00737F2E /* Responses.swift in Sources */,
 				5F07A5A0210F989100819FA2 /* EnrolledDeviceSpec.swift in Sources */,
 				5FF42BA821091F150082459F /* NetworkOperationSpec.swift in Sources */,

--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -36,7 +36,7 @@ struct ConsentAPIClient : ConsentAPI {
     
     private static func adjustURL(_ url: URL) -> URL {
         var urlString = url.absoluteString
-        if urlString.hasSuffix("auth0.com") {
+        if urlString.hasSuffix(".auth0.com") {
             urlString = urlString.replacingOccurrences(of: ".guardian", with: "")
         }
         let url = URL(string: urlString) ?? url

--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -30,17 +30,17 @@ struct ConsentAPIClient : ConsentAPI {
     let telemetryInfo: Auth0TelemetryInfo?
     
     init(baseConsentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil) {
-        self.url = ConsentAPIClient.adjustURL(baseConsentUrl)
+        self.url = ConsentAPIClient.prepareConsentUrl(baseConsentUrl)
         self.telemetryInfo = telemetryInfo
     }
     
-    private static func adjustURL(_ url: URL) -> URL {
-        var urlString = url.absoluteString
-        if urlString.hasSuffix(".auth0.com") {
-            urlString = urlString.replacingOccurrences(of: ".guardian", with: "")
+    /// Modifies URL by removing 'guardian' subdomain from legacy URLs and appinding consent path.
+    private static func prepareConsentUrl(_ url: URL) -> URL {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        if let host = components?.host, host.hasSuffix(".auth0.com") {
+            components?.host = host.replacingOccurrences(of: ".guardian", with: "")
         }
-        let url = URL(string: urlString) ?? url
-        return url.appendingPathComponent(path)
+        return components?.url?.appendingPathComponent(path) ?? url
     }
     
     func fetch(consentId:String, transactionToken: String, signingKey: SigningKey) -> Request<NoContent, Consent> {

--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -29,25 +29,18 @@ struct ConsentAPIClient : ConsentAPI {
     let url: URL
     let telemetryInfo: Auth0TelemetryInfo?
     
-    init(baseConsentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil, shouldModifyURL: Bool = true) {
-        self.url = shouldModifyURL ? ConsentAPIClient.adjustURL(baseConsentUrl) : baseConsentUrl
+    init(baseConsentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil) {
+        self.url = ConsentAPIClient.adjustURL(baseConsentUrl)
         self.telemetryInfo = telemetryInfo
     }
     
     private static func adjustURL(_ url: URL) -> URL {
-        guard
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-            var domainComponents = components.host?.components(separatedBy: "."),
-            domainComponents.count > 4,
-            domainComponents[domainComponents.count-4] == "guardian"
-        else {
-            return url.appendingPathComponent(path, isDirectory: false)
+        var urlString = url.absoluteString
+        if urlString.hasSuffix("auth0.com") {
+            urlString = urlString.replacingOccurrences(of: ".guardian", with: "")
         }
-        
-        domainComponents.remove(at: domainComponents.count-4)
-        components.host = domainComponents.joined(separator: ".")
-        
-        return components.url?.appendingPathComponent(path, isDirectory: false) ?? url
+        let url = URL(string: urlString) ?? url
+        return url.appendingPathComponent(path)
     }
     
     func fetch(consentId:String, transactionToken: String, signingKey: SigningKey) -> Request<NoContent, Consent> {

--- a/Guardian/Guardian.swift
+++ b/Guardian/Guardian.swift
@@ -409,15 +409,14 @@ public func consent(forDomain domain: String, telemetryInfo: Auth0TelemetryInfo?
 
  - parameter url:                 URL of your Guardian server
  - parameter telemetryInfo:       information about the app, used for internal auth0 analytics purposes
- - parameter shouldModifyURL:     use false here only if you have very specific custom url for consent API
 
 
  - returns: an `ConsentAPI` instance
 
  - seealso: Guardian.ConsentAPI
  */
-public func consent(consentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil, shouldModifyURL: Bool = true) -> ConsentAPI {
-    ConsentAPIClient(baseConsentUrl: consentUrl, telemetryInfo: telemetryInfo, shouldModifyURL: shouldModifyURL)
+public func consent(consentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
+    ConsentAPIClient(baseConsentUrl: consentUrl, telemetryInfo: telemetryInfo)
 }
 
 func url(from domain: String) -> URL? {

--- a/Guardian/Guardian.swift
+++ b/Guardian/Guardian.swift
@@ -407,16 +407,17 @@ public func consent(forDomain domain: String, telemetryInfo: Auth0TelemetryInfo?
     .consent(url: URL(string: "https://<tenant>.<region>.auth0.com/")!)
  ```
 
- - parameter url:           URL of your Guardian server
+ - parameter url:                 URL of your Guardian server
  - parameter telemetryInfo:       information about the app, used for internal auth0 analytics purposes
+ - parameter shouldModifyURL:     use false here only if you have very specific custom url for consent API
 
 
  - returns: an `ConsentAPI` instance
 
  - seealso: Guardian.ConsentAPI
  */
-public func consent(consentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil) -> ConsentAPI {
-    ConsentAPIClient(baseConsentUrl: consentUrl, telemetryInfo: telemetryInfo)
+public func consent(consentUrl: URL, telemetryInfo: Auth0TelemetryInfo? = nil, shouldModifyURL: Bool = true) -> ConsentAPI {
+    ConsentAPIClient(baseConsentUrl: consentUrl, telemetryInfo: telemetryInfo, shouldModifyURL: shouldModifyURL)
 }
 
 func url(from domain: String) -> URL? {

--- a/GuardianTests/API/ConsentApiClientSpec.swift
+++ b/GuardianTests/API/ConsentApiClientSpec.swift
@@ -1,0 +1,53 @@
+// ConsentAPIClientSpec.swift
+//
+// Copyright (c) 2018 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Quick
+import Nimble
+
+@testable import Guardian
+
+class ConsentAPIClientSpec: QuickSpec {
+    
+    override class func spec() {
+        describe("init") {
+            it("should correctly handle legacy url") {
+                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://samples.guardian.en.auth0.com")!)
+                expect(consent.url).to(equal(URL(string: "https://samples.en.auth0.com/rich-consents")!))
+            }
+            
+            it("should should correctly handle new url") {
+                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://samples.en.auth0.com")!)
+                expect(consent.url).to(equal(URL(string: "https://samples.en.auth0.com/rich-consents")!))
+            }
+            
+            it("should should correctly handle new url with guardian word in it") {
+                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://sample.guardian.samples.en.auth0.com")!)
+                expect(consent.url).to(equal(URL(string: "https://sample.guardian.samples.en.auth0.com/rich-consents")!))
+            }
+            
+            it("should take url as is if parameter is set") {
+                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://sample.samples.guardian.en.auth0.com/test")!, shouldModifyURL: false)
+                expect(consent.url).to(equal(URL(string: "https://sample.samples.guardian.en.auth0.com/test")!))
+            }
+        }
+    }
+}

--- a/GuardianTests/API/ConsentApiClientSpec.swift
+++ b/GuardianTests/API/ConsentApiClientSpec.swift
@@ -41,6 +41,11 @@ class ConsentAPIClientSpec: QuickSpec {
                     URL(string: "https://samples.auth0.com/rich-consents")!
                 ),
                 (
+                    "should handle url with additional path",
+                    URL(string: "https://samples.guardian.eu.auth0.com/path/")!,
+                    URL(string: "https://samples.eu.auth0.com/path/rich-consents")!
+                ),
+                (
                     "should handle canonical tenant url with region",
                     URL(string: "https://samples.eu.auth0.com")!,
                     URL(string: "https://samples.eu.auth0.com/rich-consents")!

--- a/GuardianTests/API/ConsentApiClientSpec.swift
+++ b/GuardianTests/API/ConsentApiClientSpec.swift
@@ -29,24 +29,43 @@ class ConsentAPIClientSpec: QuickSpec {
     
     override class func spec() {
         describe("init") {
-            it("should correctly handle legacy url") {
-                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://samples.guardian.en.auth0.com")!)
-                expect(consent.url).to(equal(URL(string: "https://samples.en.auth0.com/rich-consents")!))
-            }
+            let testcases: [(description: String, input: URL, output: URL)] = [
+                (
+                    "should handle legacy url with region",
+                    URL(string: "https://samples.guardian.eu.auth0.com")!,
+                    URL(string: "https://samples.eu.auth0.com/rich-consents")!
+                ),
+                (
+                    "should handle legacy url without region",
+                    URL(string: "https://samples.guardian.auth0.com")!,
+                    URL(string: "https://samples.auth0.com/rich-consents")!
+                ),
+                (
+                    "should handle canonical tenant url with region",
+                    URL(string: "https://samples.eu.auth0.com")!,
+                    URL(string: "https://samples.eu.auth0.com/rich-consents")!
+                ),
+                (
+                    "should handle canonical tenant url without region",
+                    URL(string: "https://samples.auth0.com")!,
+                    URL(string: "https://samples.auth0.com/rich-consents")!
+                ),
+                (
+                    "should handle custom domain url",
+                    URL(string: "https://custom-domain.com")!,
+                    URL(string: "https://custom-domain.com/rich-consents")!
+                ),
+                (
+                    "should handle custom domain url with guardian subdomain",
+                    URL(string: "https://guardian.custom-domain.com")!,
+                    URL(string: "https://guardian.custom-domain.com/rich-consents")!
+                )
+            ]
             
-            it("should should correctly handle new url") {
-                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://samples.en.auth0.com")!)
-                expect(consent.url).to(equal(URL(string: "https://samples.en.auth0.com/rich-consents")!))
-            }
-            
-            it("should should correctly handle new url with guardian word in it") {
-                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://sample.guardian.samples.en.auth0.com")!)
-                expect(consent.url).to(equal(URL(string: "https://sample.guardian.samples.en.auth0.com/rich-consents")!))
-            }
-            
-            it("should take url as is if parameter is set") {
-                let consent = ConsentAPIClient(baseConsentUrl: URL(string: "https://sample.samples.guardian.en.auth0.com/test")!, shouldModifyURL: false)
-                expect(consent.url).to(equal(URL(string: "https://sample.samples.guardian.en.auth0.com/test")!))
+            testcases.forEach { (description: String, input: URL, output: URL) in
+                it(description) {
+                    expect(ConsentAPIClient(baseConsentUrl: input).url).to(equal(output))
+                }
             }
         }
     }


### PR DESCRIPTION
Modify the Guardian SDKs to be more “forgiving” when using the https://{tenant}.guardian.{region}.auth0.com url to call the consent api functions and do the URL manipulation to remove the .guardian. sub-domain.

Also I created optional shouldModifyURL flag that is true by default. However, user can switch it to provide URL to be used as is. That will let users create quick workarounds if consent url or domain rules ever changes.