### PR TITLE
Handle case where consent client is created with an /appliance-mfa url

### DIFF
--- a/Guardian/API/ConsentAPIClient.swift
+++ b/Guardian/API/ConsentAPIClient.swift
@@ -40,6 +40,11 @@ struct ConsentAPIClient : ConsentAPI {
         if let host = components?.host, host.hasSuffix(".auth0.com") {
             components?.host = host.replacingOccurrences(of: ".guardian", with: "")
         }
+        
+        if url.lastPathComponent == "appliance-mfa" {
+            components?.path = url.deletingLastPathComponent().path
+        }
+        
         return components?.url?.appendingPathComponent(path) ?? url
     }
     

--- a/GuardianTests/API/ConsentApiClientSpec.swift
+++ b/GuardianTests/API/ConsentApiClientSpec.swift
@@ -64,6 +64,16 @@ class ConsentAPIClientSpec: QuickSpec {
                     "should handle custom domain url with guardian subdomain",
                     URL(string: "https://guardian.custom-domain.com")!,
                     URL(string: "https://guardian.custom-domain.com/rich-consents")!
+                ),
+                (
+                    "should handle canonical tenant url with appliance-mfa path",
+                    URL(string: "https://samples.eu.auth0.com/appliance-mfa")!,
+                    URL(string: "https://samples.eu.auth0.com/rich-consents")!
+                ),
+                (
+                    "should handle custom domain url with appliance-mfa path",
+                    URL(string: "https://custom-domain.com/appliance-mfa")!,
+                    URL(string: "https://custom-domain.com/rich-consents")!
                 )
             ]
             


### PR DESCRIPTION
Allows usage of older style guardian urls consisting of the tenant domain with an "appliance-mfa" path when using ConsentsAPIClient. This allow for backwards compatibility that clients still using those style of urls when setting up guardian without them having to make changes.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
